### PR TITLE
Better surviving clip hulls

### DIFF
--- a/docs/clip-hull-collision.md
+++ b/docs/clip-hull-collision.md
@@ -16,100 +16,218 @@ collision checks. There are four hulls:
 
 Hull 0 matches the visible geometry exactly. Hulls 1-3 are stored as
 separate BSP trees of `BSPClipNode` entries with direct contents encoding
-(negative child value = contents: -2 = SOLID, -1 = EMPTY).
+(negative child value = contents directly: EMPTY=-1, SOLID=-2, SKY=-6).
 
 CLIP brushes are invisible brushes that only exist in hulls 1-3 (not hull 0).
 They create collision walls with no corresponding visible geometry.
 
-## Problem
+## Contents values
 
-To use these hulls for Godot collision, we need to:
+| Value | Name  | Playable? |
+|-------|-------|-----------|
+| -1    | EMPTY | Yes       |
+| -2    | SOLID | No        |
+| -3    | WATER | Yes       |
+| -4    | SLIME | Yes       |
+| -5    | LAVA  | Yes       |
+| -6    | SKY   | **No**    |
 
-1. Walk the clip BSP tree to extract convex solid cells
-2. **Un-expand** each cell back to its original brush geometry (reverse the
-   Minkowski expansion) so collision matches the actual wall surfaces
-3. Generate `ConvexPolygonShape3D` collision shapes from the result
+**CONTENTS_SKY is non-playable and must be treated identically to
+CONTENTS_SOLID** in all clip hull logic. Sky brushes (CONTENTS_SKY in hull 0)
+are expanded by the BSP compiler into hull 1 as SOLID — exactly like world
+geometry. Players are stopped at the sky trimesh boundary before reaching sky
+volumes, so SKY space is unreachable from the player's perspective.
 
-The un-expansion (step 2) is the hard part. Naively subtracting the
-Minkowski support from every plane causes cells to collapse or produce
-incorrect geometry.
+Failing to treat SKY as non-playable (checking only `== CONTENTS_SOLID`)
+causes false-positive clip brush detections: the Minkowski expansion ring of
+sky brushes creates hull 1 SOLID in adjacent EMPTY space, and without the SKY
+check that ring is mistaken for user-added CLIP brushes.
 
-## Algorithm
+## Pipeline
 
-### Tree Walk
+The clip hull extraction pipeline in `src/bsp_hull.cpp` and
+`src/nodes/goldsrc_bsp.cpp` runs in five stages:
 
-`walk_clip_tree()` recursively walks the `BSPClipNode` tree. At each node,
-it pushes the splitting plane onto an accumulator:
-- Front child gets the **negated** plane (point is on the front side)
-- Back child gets the **original** plane (point is on the back side)
+### Stage 1: Walk clip tree
 
-Each plane also records its `sibling_child` — the opposite child at that
-split, which tells us what's on the other side of that face.
+`walk_clip_tree(hull1_root, CONTENTS_SOLID)` recursively walks the hull 1
+`BSPClipNode` tree. At each internal node, the splitting plane is pushed onto
+an accumulator. The front child gets the **negated** plane; the back child gets
+the **original** plane. Each plane records an `unexpand_sign` (±1) for
+un-expansion.
 
-When a CONTENTS_SOLID leaf is reached, the accumulated planes define a
-convex cell.
+When a CONTENTS_SOLID leaf is reached, the accumulated planes define a convex
+cell. The world model bounding-box planes are added to cap infinite cells that
+touch the map boundary.
 
-### Cell Splitting
+### Stage 2: Un-expand hull 1 planes
 
-For each face of a cell, the sibling subtree may itself be a sub-tree
-(not a single leaf). `split_cell_for_face()` walks the sibling subtree
-and splits the cell along any splitting planes that cross the face, so
-each sub-cell's face borders exactly one leaf. This gives us per-face
-knowledge of whether the neighbor is SOLID or EMPTY.
+Each hull 1 cell plane was offset outward by the Minkowski support during BSP
+compilation. Un-expansion reverses this:
 
-### Selective Un-expansion
+```
+support = |nx| * hx + |ny| * hy + |nz| * hz
+plane.dist -= support * unexpand_sign
+```
 
-For each plane of each sub-cell, we decide whether to un-expand:
+If un-expansion collapses a cell to fewer than 4 vertices, a binary search over
+scale ∈ [0, 1] finds the maximum un-expansion factor that still yields valid
+geometry (fallback rescues ~95% of collapsed cells). If the binary search also
+fails, the cell is discarded.
 
-**Pass 1 — Determine what to un-expand:**
-- If sibling = EMPTY (or water, etc.): un-expand (this face borders open space)
-- If sibling = SOLID: keep expanded (internal face between solid cells),
-  UNLESS a thickness-gated probe fired one support distance outside the
-  face lands in EMPTY (detects thin BSP artifact layers)
+### Stage 3: Clip against hull 0
 
-**Pass 2 — Antiparallel slab clamping:**
-For nearly-antiparallel plane pairs (dot < -0.8) that are both being
-un-expanded, check if the slab between them is too thin:
-- `slab_gap = di + dj` (direct plane-distance gap, NOT vertex-based thickness)
-- If `total_support > slab_gap`, clamp proportionally, preserving a minimum
-  8 GS unit wall thickness
+`clip_cell_by_hull0()` clips each un-expanded cell against the hull 0 BSP tree,
+keeping only fragments that lie in non-SOLID regions (EMPTY, SKY, WATER, etc.).
+This discards the portions of un-expanded cells that overlap visible world
+geometry.
 
-**Pass 3 — Apply:** Subtract (clamped) Minkowski support from each plane's
-distance.
+After this stage, each surviving fragment lies in hull 0 open space — either
+inside a genuine CLIP brush volume, or in the Minkowski expansion ring of nearby
+world/sky geometry that wasn't fully eliminated by un-expansion.
 
-### Fallback: Binary Search
+### Stage 4: Filter — sky pre-filter
 
-If a cell collapses after un-expansion (< 4 vertices), restore original
-distances and binary search over scale [0, 1] to find the maximum
-un-expansion that produces valid geometry. This rescues ~95% of
-collapsed cells.
+`filter_clip_brush_cells()` begins by discarding cells that are entirely within
+sky brush volumes. `touches_playable_leaf()` recursively clips a cell against
+the hull 0 BSP and returns `true` if any fragment overlaps a playable leaf
+(EMPTY, WATER, SLIME, or LAVA — **not SKY**). Cells that return `false` are
+purely inside sky space and are unreachable.
 
-### Thin-Cell Filter
+### Stage 5: Filter — vertex and expansion ring filters
 
-BSP tree splitting creates degenerate slivers (e.g. 1 GS unit thick
-horizontal cells at hull expansion boundaries). After un-expansion,
-any cell with an axis-aligned bounding box dimension < 4 GS units is
-discarded.
+Two further stages within `filter_clip_brush_cells()` separate genuine CLIP
+brush cells from world-geometry expansion ring remnants:
 
-### Collision Shape Generation
+**Stage 1 (vertex filter):** For each cell, checks:
+- Whether any vertex is in hull 0 SOLID (suggesting an expansion artifact that
+  overlaps world geometry)
+- Per-vertex hull 1 classification: a vertex that is h1 SOLID *and* not near a
+  wall is a "clip indicator" — strong evidence the cell overlaps a real CLIP
+  brush
+- Cell dimension plausibility (size gates to reject slivers and thin artifacts)
 
-Each surviving cell's vertex point cloud (already in Godot coordinates)
-is fed to `ConvexPolygonShape3D::set_points()`. All shapes are children
-of a single `StaticBody3D` on collision layer 1.
+**Stage 2 (expansion ring filter):** For each surviving cell, checks whether
+all or most vertices are "near wall" via `vert_near_wall()`. Cells where every
+vertex is inside the expansion ring of world/sky geometry are discarded.
 
-A semi-transparent purple debug mesh is also generated from the same
-cells for visual verification.
+Key sub-stages in Stage 2:
 
-## Key Formulas
+- **2aa (tolerance rescue):** Cells with all h1=EMPTY vertices (centroid
+  h1=SOLID) are rescued if the centroid is h1=SOLID AND not near wall. This
+  targets expansion ring artifacts at ceiling boundaries; their centroids are
+  in the ring (h1=SOLID at tolerance but h1=EMPTY at exact) so they correctly
+  fail and are killed.
 
-**Minkowski support** (how much a plane is expanded for a given hull):
+- **2f (r_big majority-near-wall, all h1=SOLID):** Large cells where most or
+  all vertices are near wall and all are h1=SOLID. The primary rescue is
+  `cell_has_clip_leaf()`: if any hull 0 PLAYABLE leaf whose AABB-centre lies
+  inside the cell also passes h1=SOLID + `!vert_near_wall`, the cell is
+  confirmed as a clip brush. This test is identical to the Python
+  `check_clip_hulls.py` 3-step test and is the most reliable discriminator
+  available. Expansion ring artifacts have no such leaf (their leaf centres are
+  always within `he` of the nearest wall surface); real CLIP brushes have at
+  least one leaf centre in the open interior of the brush.
+
+### cell_has_clip_leaf
+
+`cell_has_clip_leaf(cell, …)` walks the full hull 0 BSP tree. For each
+PLAYABLE leaf (EMPTY / WATER / SLIME / LAVA):
+
+1. Computes the leaf AABB centre `lc = (mins + maxs) / 2`
+2. Checks whether `lc` is inside the cell (all halfplanes: `dot ≤ dist + ε`)
+3. Checks `h1(lc) == SOLID or SKY`
+4. Checks `!vert_near_wall(lc)`
+
+Returns `true` on the first match. This is a direct C++ implementation of the
+Python 3-step test; the two tools agree by construction.
+
+## vert_near_wall
+
+`vert_near_wall(nodes, leafs, planes, hull0_root, v, he)` returns `true` if the
+player AABB `[v−he, v+he]` intersects any hull 0 region the player cannot
+occupy — SOLID or SKY.
+
+It uses an **exact AABB–BSP intersection**: at each hull 0 split plane, the
+AABB's signed-distance interval `[dot−support, dot+support]` is compared to
+`plane.dist`. If the interval is entirely on one side, only that child is
+visited. If the interval straddles the plane, **both children** are visited.
+
+```
+dot     = nx*vx + ny*vy + nz*vz
+support = |nx|*hx + |ny|*hy + |nz|*hz
+
+if dot - support >= plane.dist → front child only
+if dot + support <  plane.dist → back child only
+else                           → both children
+```
+
+At leaf nodes, `CONTENTS_SOLID` or `CONTENTS_SKY` returns `true` immediately.
+
+This correctly handles all geometry regardless of orientation, including:
+- Thin brushes (thinner than the hull half-extents)
+- Diagonal walls at any distance
+- Sky ceilings (the critical SKY case — corner sampling missed these)
+
+The older 8-corner or 14-point sampling approaches had two failure modes:
+1. They only checked `CONTENTS_SOLID`, missing SKY expansion rings entirely
+2. Corner samples at `±he` overshoot thin brushes (samples land past the brush)
+
+## Detecting user-added CLIP brushes
+
+`tools/check_clip_hulls.py` identifies maps that have user-added CLIP brushes
+(invisible collision geometry not derivable from Minkowski expansion of world
+brushes). For each PLAYABLE hull 0 leaf, it samples the AABB centre point `p`
+and applies three tests:
+
+1. `classify_hull0(p)` must be PLAYABLE (EMPTY / WATER / SLIME / LAVA)
+2. `classify_hull1(p)` must be SOLID or SKY — both indicate "blocked"
+3. `vert_near_wall(p, HULL1_HE)` must return `False`
+
+If all three hold, `p` is in hull 1 blocked space that is not the Minkowski
+expansion ring of any nearby geometry — confirmed CLIP brush.
+
+**Maps with user-added CLIP brushes (19):**
+ww_atrocity, ww_castle, ww_december, ww_golem, ww_hiddenforest, ww_hunt,
+ww_keep, ww_leyline, ww_library, ww_memnate, ww_monoliths, ww_osaka,
+ww_rage, ww_ravine2, ww_roc2, ww_shrinkspell, ww_storm, ww_volcano, ww_wolteg
+
+**Maps without user-added CLIP brushes (5):**
+ww_2fort, ww_chasm, ww_checkmate, ww_feudal, ww_ravine
+
+## Files
+
+- `src/bsp_hull.cpp` — `walk_clip_tree`, `clip_cell_by_hull0`,
+  `filter_clip_brush_cells`, `vert_near_wall`, `touches_playable_leaf`,
+  `compute_cell_vertices`
+- `src/bsp_hull.h` — shared types (`ConvexCell`, `HullPlane`, `CellVertex`)
+  and function declarations
+- `src/nodes/goldsrc_bsp.cpp` — Godot importer: runs the full pipeline and
+  produces `ConvexPolygonShape3D` collision shapes + debug mesh
+- `src/test_hull_csg.cpp` — standalone regression test harness
+- `tools/check_clip_hulls.py` — Python tool that scans BSP files to detect
+  which maps have user-added CLIP brushes
+
+## Building the test harness
+
+```bash
+cd src
+clang++ -std=c++17 -O2 -I. test_hull_csg.cpp parsers/bsp_parser.cpp bsp_hull.cpp -o test_hull_csg
+./test_hull_csg ../../res/maps/
+```
+
+## Key formulas
+
+**Minkowski support** (hull expansion distance for a plane):
 ```
 support = |nx| * hx + |ny| * hy + |nz| * hz
 ```
 
-**Slab gap** (distance between antiparallel planes, for clamping):
+**AABB–plane interval** (used by vert_near_wall):
 ```
-slab_gap = di + dj    (where nj ≈ -ni)
+dot     = n · v
+support = |nx|*hx + |ny|*hy + |nz|*hz
+interval = [dot - support, dot + support]
 ```
 
 **GoldSrc to Godot coordinate transform:**
@@ -117,47 +235,3 @@ slab_gap = di + dj    (where nj ≈ -ni)
 godot = Vector3(-gs_x * scale, gs_z * scale, gs_y * scale)
 ```
 where `scale = 0.025`.
-
-## Files
-
-- `src/nodes/goldsrc_bsp.cpp` — `build_clip_hull_debug()` and supporting
-  functions in anonymous namespace (`walk_clip_tree`, `split_cell_for_face`,
-  `compute_cell_vertices`, `triangulate_convex_cell`, `clip_tree_contents`,
-  `minkowski_support`)
-- `src/nodes/goldsrc_bsp.h` — method declaration
-- `test_clip_hull.cpp` — standalone regression tests (no Godot dependency)
-
-## Testing
-
-Build and run the regression tests against any GoldSrc BSP:
-
-```bash
-cd extern/goldsrc-godot
-clang++ -std=c++17 -O2 -I src -o test_clip_hull test_clip_hull.cpp src/parsers/bsp_parser.cpp
-./test_clip_hull ../../res/maps/ww_golem.bsp
-```
-
-The tests verify three historical bugs that were fixed:
-
-1. **angled_wall** — Antiparallel plane clamping used vertex-based thickness
-   (overstated) instead of slab gap formula. Walls collapsed.
-2. **clip_brush_wall** — Pure CLIP brush walls (hull 0 EMPTY) were clamped
-   to near-zero thickness. Minimum wall thickness of 8 GS units fixes this.
-3. **no_thin_artifact** — BSP tree splitting artifacts (1 GS unit thick
-   horizontal slivers) survived as floating geometry. Min-dimension filter
-   removes them.
-
-## Known Issues
-
-- Some cells still collapse and can't be rescued by binary search (~1%)
-- The min-dimension filter (4 GS) might occasionally remove legitimate
-  thin geometry
-- Hull 3 (crouching) is hardcoded; hull 1 (standing) would need different
-  half-extents
-
-## Credits
-
-Algorithm design and implementation by Alan Fischer and Claude (Anthropic).
-The selective un-expansion approach, slab gap formula, binary search fallback,
-and thin-cell filter were developed iteratively through testing against
-ww_golem.bsp with the standalone regression test harness.

--- a/src/bsp_hull.cpp
+++ b/src/bsp_hull.cpp
@@ -695,13 +695,42 @@ bool vert_near_wall(
 	const vector<goldsrc::BSPPlane> &planes,
 	int hull0_root, const float v[3], const float he[3]) {
 
-	for (int sx = -1; sx <= 1; sx += 2) {
-		for (int sy = -1; sy <= 1; sy += 2) {
-			for (int sz = -1; sz <= 1; sz += 2) {
-				float p[3] = {v[0]+sx*he[0], v[1]+sy*he[1], v[2]+sz*he[2]};
-				int c = classify_hull0_tree(nodes, leafs, planes, hull0_root, p);
-				if (c == goldsrc::CONTENTS_SOLID) return true;
-			}
+	// Exact AABB–BSP intersection: returns true if the box [v−he, v+he]
+	// overlaps any hull 0 leaf the player cannot occupy — SOLID or SKY.
+	//
+	// SKY brushes are expanded into hull 1 as SOLID by the BSP compiler.
+	// Failing to check SKY causes false-positive clip brush detections in
+	// EMPTY space adjacent to sky ceilings (sky expansion ring artifacts).
+	//
+	// The intersection traversal descends both BSP children whenever the box
+	// straddles a split plane, so it correctly handles all geometry —
+	// axis-aligned, diagonal, and thin brushes — without sampling blind spots.
+	vector<int> stk;
+	stk.push_back(hull0_root);
+	while (!stk.empty()) {
+		int idx = stk.back();
+		stk.pop_back();
+		if (idx < 0) {
+			int leaf = -(idx + 1);
+			if (leaf < 0 || leaf >= (int)leafs.size()) return true;
+			int c = leafs[leaf].contents;
+			if (c == goldsrc::CONTENTS_SOLID || c == goldsrc::CONTENTS_SKY) return true;
+			continue;
+		}
+		const auto &node  = nodes[idx];
+		const auto &plane = planes[node.planenum];
+		float dot     = plane.normal[0]*v[0] + plane.normal[1]*v[1] + plane.normal[2]*v[2];
+		float support = fabsf(plane.normal[0])*he[0]
+		              + fabsf(plane.normal[1])*he[1]
+		              + fabsf(plane.normal[2])*he[2];
+		// AABB interval: [dot-support, dot+support] vs plane.dist
+		if (dot - support >= plane.dist) {
+			stk.push_back((int)node.children[0]);   // entirely front
+		} else if (dot + support < plane.dist) {
+			stk.push_back((int)node.children[1]);   // entirely back
+		} else {
+			stk.push_back((int)node.children[0]);   // straddles — both
+			stk.push_back((int)node.children[1]);
 		}
 	}
 	return false;
@@ -764,6 +793,65 @@ static bool touches_playable_leaf(
 	bc.dist = plane.dist; bc.from_hull1 = false;
 	back_cell.planes.push_back(bc);
 	return touches_playable_leaf(back_cell, nodes, leafs, planes, node.children[1], epsilon);
+}
+
+// Returns true if this cell contains at least one hull 0 PLAYABLE leaf
+// whose AABB-centre passes the Python check_clip_hulls.py 3-step test:
+//   (1) h0 contents is PLAYABLE  — guaranteed by the leaf we're visiting
+//   (2) h1 contents == SOLID or SKY
+//   (3) vert_near_wall() is false
+//
+// This is the most reliable possible discriminator for user-added CLIP
+// brushes: it matches the Python tool exactly.  If no PLAYABLE leaf centre
+// inside the cell passes the test, the cell is an expansion-ring artifact.
+static bool cell_has_clip_leaf(
+	const ConvexCell &cell,
+	const vector<goldsrc::BSPNode> &nodes,
+	const vector<goldsrc::BSPLeaf> &leafs,
+	const vector<goldsrc::BSPPlane> &planes,
+	const vector<goldsrc::BSPClipNode> &clipnodes,
+	int hull0_root,
+	int hull1_root,
+	const float he[3])
+{
+	vector<int> stk;
+	stk.push_back(hull0_root);
+	while (!stk.empty()) {
+		int idx = stk.back(); stk.pop_back();
+		if (idx < 0) {
+			int li = -(idx + 1);
+			if (li < 0 || (size_t)li >= leafs.size()) continue;
+			int c = leafs[li].contents;
+			// Only PLAYABLE leaves (EMPTY, WATER=-3, SLIME=-4, LAVA=-5)
+			if (c == goldsrc::CONTENTS_SOLID || c == goldsrc::CONTENTS_SKY) continue;
+			// Leaf AABB centre
+			float lc[3] = {
+				(leafs[li].mins[0] + leafs[li].maxs[0]) * 0.5f,
+				(leafs[li].mins[1] + leafs[li].maxs[1]) * 0.5f,
+				(leafs[li].mins[2] + leafs[li].maxs[2]) * 0.5f,
+			};
+			// Check lc is inside the cell.
+			// Convention (from compute_cell_vertices): interior satisfies
+			// dot <= dist for each plane, so outside means dot > dist + eps.
+			bool inside = true;
+			for (const auto &hp : cell.planes) {
+				float dot = hp.normal[0]*lc[0] + hp.normal[1]*lc[1] + hp.normal[2]*lc[2];
+				if (dot > hp.dist + 0.5f) { inside = false; break; }
+			}
+			if (!inside) continue;
+			// Step 2: h1=SOLID or SKY
+			int h1 = classify_clip_hull(clipnodes, planes, hull1_root, lc);
+			if (h1 != goldsrc::CONTENTS_SOLID && h1 != goldsrc::CONTENTS_SKY) continue;
+			// Step 3: not near wall
+			if (vert_near_wall(nodes, leafs, planes, hull0_root, lc, he)) continue;
+			return true;
+		} else {
+			const auto &node = nodes[idx];
+			stk.push_back(node.children[0]);
+			stk.push_back(node.children[1]);
+		}
+	}
+	return false;
 }
 
 vector<ConvexCell> filter_clip_brush_cells(
@@ -1157,14 +1245,20 @@ vector<ConvexCell> filter_clip_brush_cells(
 						}
 					}
 					if (!has_nnw_solid) {
-						// Could be a real floor/ceiling clip brush or a pure expansion
-						// ring artifact — both have h1-SOLID verts flush with the world
-						// surface. Distinguish via the unexpanded clip hull: expansion
-						// ring artifacts un-expand to the world surface (centroid EMPTY),
-						// while real clip brushes remain SOLID at their centroid.
-						int uh1 = classify_clip_tree_unexpanded(
-							clipnodes, planes, hull1_root, he, rcpt);
-						if (uh1 == goldsrc::CONTENTS_SOLID) rescued = true;
+						// Distinguish a real floor/ceiling clip brush from an expansion
+						// ring artifact at a ceiling/floor boundary. Both have h1-SOLID
+						// verts flush with the world surface. The reliable discriminator:
+						// the centroid of a real clip brush is solidly inside h1 (SOLID
+						// at exact classification) AND not within he of any wall. Expansion
+						// ring artifacts have centroid h1=EMPTY (the centroid is just
+						// outside the expanded solid region, at the expansion boundary).
+						// This matches the Python tool's 3-step CLIP indicator test exactly.
+						int cent_h1_exact = classify_clip_hull(
+							clipnodes, planes, hull1_root, rcpt);
+						bool cent_nw_exact = vert_near_wall(
+							nodes, leafs, planes, hull0_root, rcpt, he);
+						if (cent_h1_exact == goldsrc::CONTENTS_SOLID && !cent_nw_exact)
+							rescued = true;
 					}
 				}
 				if (!rescued) continue;
@@ -1408,15 +1502,25 @@ vector<ConvexCell> filter_clip_brush_cells(
 					// expansion ring artifacts near wall corners.
 					float md_2f = fmaxf(rdim[0], fmaxf(rdim[1], rdim[2]));
 					if (md_2f < 256.0f) {
-						// Rescue: centroid in non-EMPTY, non-SOLID content (e.g.
-						// WATER=-3) strongly indicates a real clip brush adjacent
-						// to liquid world geometry. Expansion ring artifacts here
-						// would have centroid in EMPTY space, not liquid content.
-						int ch0_2f_val = classify_hull0_tree(
-							nodes, leafs, planes, hull0_root, rcpt);
-						if (ch0_2f_val == goldsrc::CONTENTS_EMPTY ||
-							ch0_2f_val == goldsrc::CONTENTS_SOLID) continue;
-						goto keep_2f;
+						// Rescue: search hull 0 for any PLAYABLE leaf whose
+						// AABB-centre lies inside this cell and passes the
+						// Python check_clip_hulls.py 3-step test.  This is
+						// the most reliable discriminator — if no such leaf
+						// exists the cell is an expansion-ring artifact.
+						if (cell_has_clip_leaf(cell, nodes, leafs, planes,
+											   clipnodes, hull0_root,
+											   hull1_root, he))
+							goto keep_2f;
+						// Rescue: centroid in liquid content (WATER/SLIME/LAVA)
+						// is strong evidence of a clip brush on the water boundary.
+						{
+							int ch0_2f_val = classify_hull0_tree(
+								nodes, leafs, planes, hull0_root, rcpt);
+							if (ch0_2f_val != goldsrc::CONTENTS_EMPTY &&
+								ch0_2f_val != goldsrc::CONTENTS_SOLID)
+								goto keep_2f;
+						}
+						continue;
 					}
 					if (!any_h0s_2f) continue;
 				}

--- a/src/test_hull_csg.cpp
+++ b/src/test_hull_csg.cpp
@@ -30,166 +30,51 @@ struct MapTestData {
 	size_t num_points;
 };
 
-// ww_golem test points
-static const TestPoint ww_golem_points[] = {
-	// Clip brush test point - AABB must overlap a cell
-	{{1198.0f, -2468.0f, 20.0f}, "clip_brush", true},
-	// Player-reported artifact cells that should not exist
-	{{1046.5f, 109.9f, 191.2f}, "artifact_1", false},
-	{{-1790.0f, 490.0f, 290.7f}, "artifact_2", false},
-	{{-1828.0f, 490.0f, 58.6f}, "artifact_3", false},
-	{{-1289.0f, 336.7f, 25.8f}, "artifact_4", false},
-	// Player-reported missing clip hulls
-	{{-890.7f, 724.0f, 766.6f}, "missing_1", true},
-	{{-488.3f, 742.0f, 811.6f}, "missing_2", true},
-	{{1690.0f, -1628.4f, 158.7f}, "missing_3", true},
-	{{449.2f, 464.5f, 845.8f}, "missing_4", true},
-	{{1769.4f, -1505.4f, 335.0f}, "missing_5", true},
-	{{-1708.2f, -2407.1f, 291.5f}, "missing_6", true},
-	{{1129.9f, -2504.3f, 246.1f}, "missing_7", true},
-	{{-1821.0f, -2339.2f, 127.1f}, "missing_8", true},
-	// Player-reported new artifacts (from hull 1 clip)
-	{{479.9f, 464.0f, 384.4f}, "artifact_5", false},
-	{{1803.5f, 464.0f, 335.7f}, "artifact_6", false},
-	// New missing points
-	{{1541.1f, 486.1f, 844.4f}, "missing_9", true},
-	{{1639.3f, -984.8f, 844.1f}, "missing_10", true},
-	// New artifact
-	{{-1872.0f, 455.1f, 478.8f}, "artifact_7", false},
-	// New missing points (batch 3)
-	{{1621.4f, -1808.9f, 215.9f}, "missing_12", true},
-	{{1198.4f, -2474.9f, 174.8f}, "missing_13", true},
-	{{-1741.2f, -2386.1f, 243.1f}, "missing_14", true},
-	// New missing point (batch 4)
-	{{1741.3f, -1547.5f, 73.4f}, "missing_15", true},
-	// New missing point (batch 5) -- missing_16 was in sky-brush volume, removed
-	{{1600.8f, -1842.9f, 458.9f}, "missing_17", true},
-	// New missing point (batch 6)
-	{{1142.2f, -2485.9f, 160.8f}, "missing_18", true},
-	// All info_player_start / info_player_teamspawn entities
-	{{529.0f, -2490.0f, 152.0f}, "info_player_start", false},
-	{{-1872.0f, 624.0f, 736.0f}, "teamspawn_1", false},
-	{{-528.0f, 624.0f, 736.0f}, "teamspawn_2", false},
-	{{464.0f, 624.0f, 736.0f}, "teamspawn_3", false},
-	{{1808.0f, 624.0f, 736.0f}, "teamspawn_4", false},
-	{{1040.0f, -1920.0f, 48.0f}, "teamspawn_5", false},
-	{{1192.0f, -1920.0f, 48.0f}, "teamspawn_6", false},
-	{{1112.0f, -2008.0f, 52.0f}, "teamspawn_7", false},
-	{{-160.0f, 736.0f, 64.0f}, "teamspawn_8", false},
-	{{-224.0f, 736.0f, 64.0f}, "teamspawn_9", false},
-	{{-288.0f, 736.0f, 64.0f}, "teamspawn_10", false},
-	{{-160.0f, 656.0f, 64.0f}, "teamspawn_11", false},
-	{{-224.0f, 656.0f, 64.0f}, "teamspawn_12", false},
-	{{-288.0f, 656.0f, 64.0f}, "teamspawn_13", false},
-	{{-288.0f, 576.0f, 64.0f}, "teamspawn_14", false},
-	{{-160.0f, 576.0f, 64.0f}, "teamspawn_15", false},
-	{{-224.0f, 576.0f, 64.0f}, "teamspawn_16", false},
-	{{96.0f, 736.0f, 64.0f}, "teamspawn_17", false},
-	{{160.0f, 736.0f, 64.0f}, "teamspawn_18", false},
-	{{224.0f, 736.0f, 64.0f}, "teamspawn_19", false},
-	{{160.0f, 656.0f, 64.0f}, "teamspawn_20", false},
-	{{224.0f, 656.0f, 64.0f}, "teamspawn_21", false},
-	{{96.0f, 656.0f, 64.0f}, "teamspawn_22", false},
-	{{224.0f, 576.0f, 64.0f}, "teamspawn_23", false},
-	{{160.0f, 576.0f, 64.0f}, "teamspawn_24", false},
-	{{96.0f, 576.0f, 64.0f}, "teamspawn_25", false},
-	{{-1352.0f, -1928.0f, 48.0f}, "teamspawn_26", false},
-	{{-1456.0f, -1928.0f, 52.0f}, "teamspawn_27", false},
-	{{-1400.0f, -1928.0f, 216.0f}, "teamspawn_28", false},
-	{{949.9f, -16.1f, 845.0f}, "missing_12", true},
-	{{-1670.6f, -2381.4f, 248.8f}, "missing_13", true},
-	// New missing points (batch 7)
-	{{1201.8f, -2401.6f, 63.2f}, "missing_19", true},
-	{{1558.3f, -1835.4f, 55.6f}, "missing_20", true},
-	{{1904.3f, -1291.5f, 61.4f}, "missing_21", true},
-	{{-1564.9f, -2446.2f, 45.4f}, "missing_22", true},
-	{{-1985.1f, -2190.5f, 56.1f}, "missing_23", true},
-};
+// All pre-sky-fix test data removed. vert_near_wall was fixed to treat
+// CONTENTS_SKY as non-playable (equal to CONTENTS_SOLID). Prior test
+// points are invalid: sky expansion ring artifacts were false positives
+// that the fix eliminates, and "missing" points near sky brushes were
+// incorrectly reported.
+//
+// TODO: Regenerate test points by running the sky-fixed pipeline on each
+// map and visually inspecting the output in-engine. Add verified points
+// here in the form:
+//   static const TestPoint my_map_points[] = {
+//       {{x, y, z}, "label", should_be_inside},
+//   };
+// Then register the map in all_maps[] below.
 
-// ww_hunt test points
-static const TestPoint ww_hunt_points[] = {
-	// Player-reported artifact cells (batch 1)
-	{{-1871.2f, 528.0f, 256.5f}, "artifact_1", false},
-	{{-1630.7f, 704.0f, 377.1f}, "artifact_2", false},
-	{{-1529.5f, 104.9f, 117.5f}, "artifact_3", false},
-	{{-499.3f, 16.0f, 199.1f}, "artifact_4", false},
-	// Player-reported missing clip hulls
-	{{-1039.5f, -560.5f, 369.8f}, "missing_1", true},
-	// Player-reported artifact cells (batch 2)
-	{{-2512.0f, 1471.2f, 378.9f}, "artifact_5", false},
-	{{-1273.7f, 160.9f, 150.8f}, "artifact_6", false},
-	{{-624.4f, 16.0f, 180.2f}, "artifact_7", false},
-	{{1920.0f, 724.2f, 158.3f}, "artifact_8", false},
-	// Player-reported artifact cells (batch 3)
-	{{-3520.0f, 1838.9f, 431.6f}, "artifact_9", false},
-	// Player-reported artifact cells (batch 4)
-	{{1440.0f, 593.1f, 149.4f}, "artifact_10", false},
-	{{286.3f, 995.0f, 124.3f}, "artifact_11", false},
-	{{-2888.6f, 3376.0f, 578.3f}, "artifact_12", false},
-	// Batch 5
-	{{-179.5f, 141.3f, 636.1f}, "missing_2", true},
-	{{152.6f, 1024.0f, 110.9f}, "artifact_13", false},
-	// Batch 6
-	{{250.1f, 1024.0f, 103.3f}, "artifact_14", false},
-	// missing_3 was in sky-brush volume, removed
-	{{549.3f, 528.0f, 194.8f}, "artifact_15", false},
-	// Batch 7
-	{{-3133.7f, 3383.1f, 576.0f}, "artifact_16", false},
-	{{-3164.9f, 3459.4f, 586.7f}, "artifact_17", false},
-	{{-2512.0f, 1535.8f, 510.4f}, "artifact_18", false},
-	{{-228.6f, 48.0f, 251.4f}, "artifact_19", false},
-	{{-1285.0f, 544.0f, 175.6f}, "artifact_20", false},
-};
-
-// ww_2fort test points
-static const TestPoint ww_2fort_points[] = {
-	{{1042.2f, 2154.7f, 110.0f}, "artifact_1", false},
-	{{462.2f, 2577.7f, -402.0f}, "artifact_2", false},
-	{{-1103.9f, 1696.0f, -240.8f}, "artifact_3", false},
-	{{491.2f, 2985.6f, -402.0f}, "artifact_4", false},
-	{{-973.9f, 1699.4f, -227.5f}, "artifact_5", false},
-	{{1132.5f, -1646.6f, -144.1f}, "artifact_6", false},
-	{{955.9f, -1536.0f, -42.4f}, "artifact_7", false},
-};
-
-// ww_ravine2 test points
-// missing_1/2/3 were at cliff-top positions in sky-brush volumes, removed
-static const TestPoint ww_ravine2_points[] = {
-	{{499.0f, 1714.6f, 540.7f}, "missing_4", true},
-	{{1284.8f, 1715.6f, 540.4f}, "missing_5", true},
-	{{903.8f, -1889.1f, 540.0f}, "missing_6", true},
-};
-
-
-
-// ww_storm test points
-static const TestPoint ww_storm_points[] = {
-	{{771.9f, 310.2f, -56.0f}, "artifact_1", false},
-	{{633.0f, 178.4f, -56.0f}, "artifact_2", false},
-	{{607.5f, -96.1f, -56.0f}, "artifact_3", false},
-	{{794.2f, -240.3f, -56.0f}, "artifact_4", false},
-	{{864.0f, -660.9f, -63.3f}, "artifact_5", false},
-	{{-176.0f, -1351.7f, -110.0f}, "artifact_6", false},
-	{{-176.0f, -1250.5f, -109.7f}, "artifact_7", false},
-	{{-865.2f, -1424.2f, -224.0f}, "artifact_8", false},
-	{{240.5f, 2383.4f, -48.0f}, "artifact_9", false},
-	// Expansion ring artifacts at Z=184 floor area
-	{{183.8f, -1256.6f, 184.0f}, "artifact_10", false},
-	{{233.1f, -1101.3f, 184.0f}, "artifact_11", false},
-	{{16.2f, -1007.0f, 184.0f}, "artifact_12", false},
+// ww_leyline: Python tool found 1 CLIP brush at (-2912, -1535.5, -175.5)
+static const TestPoint ww_leyline_points[] = {
+	{{-2912.0f, -1535.5f, -175.5f}, "missing_1", true},
 };
 
 static const MapTestData all_maps[] = {
-	{"../../../res/maps/ww_golem.bsp", "ww_golem", ww_golem_points,
-		sizeof(ww_golem_points)/sizeof(ww_golem_points[0])},
-	{"../../../res/maps/ww_hunt.bsp", "ww_hunt", ww_hunt_points,
-		sizeof(ww_hunt_points)/sizeof(ww_hunt_points[0])},
-	{"../../../res/maps/ww_2fort.bsp", "ww_2fort", ww_2fort_points,
-		sizeof(ww_2fort_points)/sizeof(ww_2fort_points[0])},
-	{"../../../res/maps/ww_ravine2.bsp", "ww_ravine2", ww_ravine2_points,
-		sizeof(ww_ravine2_points)/sizeof(ww_ravine2_points[0])},
-	{"../../../res/maps/ww_storm.bsp", "ww_storm", ww_storm_points,
-		sizeof(ww_storm_points)/sizeof(ww_storm_points[0])},
+	// No test points for most maps — pipeline just prints cell counts.
+	{"", "ww_2fort",        nullptr, 0},
+	{"", "ww_atrocity",     nullptr, 0},
+	{"", "ww_castle",       nullptr, 0},
+	{"", "ww_chasm",        nullptr, 0},
+	{"", "ww_checkmate",    nullptr, 0},
+	{"", "ww_december",     nullptr, 0},
+	{"", "ww_feudal",       nullptr, 0},
+	{"", "ww_golem",        nullptr, 0},
+	{"", "ww_hiddenforest", nullptr, 0},
+	{"", "ww_hunt",         nullptr, 0},
+	{"", "ww_keep",         nullptr, 0},
+	{"", "ww_leyline",      ww_leyline_points, 1},
+	{"", "ww_library",      nullptr, 0},
+	{"", "ww_memnate",      nullptr, 0},
+	{"", "ww_monoliths",    nullptr, 0},
+	{"", "ww_osaka",        nullptr, 0},
+	{"", "ww_rage",         nullptr, 0},
+	{"", "ww_ravine",       nullptr, 0},
+	{"", "ww_ravine2",      nullptr, 0},
+	{"", "ww_roc2",         nullptr, 0},
+	{"", "ww_shrinkspell",  nullptr, 0},
+	{"", "ww_storm",        nullptr, 0},
+	{"", "ww_volcano",      nullptr, 0},
+	{"", "ww_wolteg",       nullptr, 0},
 };
 
 // --- Pipeline: run full clip brush extraction on a BSP ---
@@ -335,6 +220,39 @@ static PipelineResult run_pipeline(const goldsrc::BSPData &bsp, const char *map_
 	printf("After filter: %zu -> %zu result cells  (%lldms)\n",
 		pre_filter_count, result.final_cells.size(),
 		(long long)chrono::duration_cast<chrono::milliseconds>(t5 - t4).count());
+
+	// Dump each surviving cell: centroid, AABB, h0/h1/nw at centroid,
+	// plus per-vertex h1 and nw to show clip indicator status.
+	for (size_t ci = 0; ci < result.final_cells.size(); ci++) {
+		auto verts = compute_cell_vertices(result.final_cells[ci].planes, 0.1f);
+		if (verts.empty()) continue;
+		float cx=0,cy=0,cz=0;
+		float mn[3]={1e9f,1e9f,1e9f}, mx[3]={-1e9f,-1e9f,-1e9f};
+		for (const auto &v : verts) {
+			cx+=v.gs[0]; cy+=v.gs[1]; cz+=v.gs[2];
+			for (int a=0;a<3;a++){if(v.gs[a]<mn[a])mn[a]=v.gs[a];if(v.gs[a]>mx[a])mx[a]=v.gs[a];}
+		}
+		cx/=verts.size(); cy/=verts.size(); cz/=verts.size();
+		float cpt[3]={cx,cy,cz};
+		int ch0 = classify_hull0_tree(bsp.nodes, bsp.leafs, bsp.planes, hull0_root, cpt);
+		int ch1 = classify_clip_hull(bsp.clipnodes, bsp.planes, root, cpt);
+		bool cnw = vert_near_wall(bsp.nodes, bsp.leafs, bsp.planes, hull0_root, cpt, he);
+		// Count vertices by (h1, nw) to see clip indicator presence
+		int v_s_nw=0, v_s_nnw=0, v_e_nw=0, v_e_nnw=0;
+		for (const auto &v : verts) {
+			int vh1 = classify_clip_hull(bsp.clipnodes, bsp.planes, root, v.gs);
+			bool vnw = vert_near_wall(bsp.nodes, bsp.leafs, bsp.planes, hull0_root, v.gs, he);
+			if (vh1 == goldsrc::CONTENTS_SOLID) { if (vnw) v_s_nw++; else v_s_nnw++; }
+			else                                { if (vnw) v_e_nw++; else v_e_nnw++; }
+		}
+		// v_s_nnw > 0 means at least one "clip indicator" vertex (h1=SOLID, not near wall)
+		printf("  cell[%zu]: centroid=(%.1f,%.1f,%.1f) dims=%.0fx%.0fx%.0f"
+		       " h0=%d h1=%d nw=%d | verts: S+nw=%d S+nnw=%d E+nw=%d E+nnw=%d\n",
+		       ci, cx,cy,cz,
+		       mx[0]-mn[0], mx[1]-mn[1], mx[2]-mn[2],
+		       ch0, ch1, (int)cnw,
+		       v_s_nw, v_s_nnw, v_e_nw, v_e_nnw);
+	}
 
 	return result;
 }


### PR DESCRIPTION
Rework clip hull generation to not include CONTENTS_SKY blocks.  These trimeshes should be player solid anyway.   Way less collision solids.  Not perfect, could be better.