### PR TITLE
Fix PVS grouping: eliminate orphans, remove redundant sky_surfaces group

### DIFF
--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -424,8 +424,7 @@ static void collect_spatial_groups(
 	const std::vector<int> &raw_to_parsed,
 	int node_index, int current_depth, int target_depth,
 	std::vector<std::vector<int>> &groups,
-	std::vector<std::vector<int>> &leaf_groups,
-	std::vector<int> &orphan_faces)
+	std::vector<std::vector<int>> &leaf_groups)
 {
 	if (node_index < 0) return; // leaf — handled by collect_leaves_recursive
 	if ((size_t)node_index >= nodes.size()) return;
@@ -441,21 +440,30 @@ static void collect_spatial_groups(
 		return;
 	}
 
-	// Above target depth: this node's own faces become orphans
-	for (uint16_t i = 0; i < node.numfaces; i++) {
-		int raw_idx = (int)node.firstface + i;
-		if (raw_idx < (int)raw_to_parsed.size()) {
-			int parsed = raw_to_parsed[raw_idx];
-			if (parsed >= 0) {
-				orphan_faces.push_back(parsed);
+	// Faces on this node's splitting plane get their own group with pvs_leaves =
+	// all descendant leaves, so they participate in PVS culling like any other face.
+	if (node.numfaces > 0) {
+		std::vector<int> node_faces;
+		for (uint16_t i = 0; i < node.numfaces; i++) {
+			int raw_idx = (int)node.firstface + i;
+			if (raw_idx < (int)raw_to_parsed.size()) {
+				int parsed = raw_to_parsed[raw_idx];
+				if (parsed >= 0)
+					node_faces.push_back(parsed);
 			}
+		}
+		if (!node_faces.empty()) {
+			groups.push_back(std::move(node_faces));
+			std::vector<int> subtree_leaves;
+			collect_leaves_recursive(nodes, leafs, node_index, subtree_leaves);
+			leaf_groups.push_back(std::move(subtree_leaves));
 		}
 	}
 
 	// Recurse into children
 	for (int c = 0; c < 2; c++) {
 		collect_spatial_groups(nodes, leafs, raw_to_parsed, node.children[c],
-			current_depth + 1, target_depth, groups, leaf_groups, orphan_faces);
+			current_depth + 1, target_depth, groups, leaf_groups);
 	}
 }
 
@@ -1163,9 +1171,8 @@ void GoldSrcBSP::build_mesh() {
 
 			vector<vector<int>> bsp_groups;
 			vector<vector<int>> bsp_leaf_groups;
-			vector<int> orphan_indices;
 			collect_spatial_groups(bsp_data.nodes, bsp_data.leafs, bsp_data.raw_to_parsed,
-				root_node, 0, TARGET_DEPTH, bsp_groups, bsp_leaf_groups, orphan_indices);
+				root_node, 0, TARGET_DEPTH, bsp_groups, bsp_leaf_groups);
 
 			// Convert parsed face indices to FaceRef vectors
 			for (size_t gi = 0; gi < bsp_groups.size(); gi++) {
@@ -1183,42 +1190,10 @@ void GoldSrcBSP::build_mesh() {
 				}
 			}
 
-			// Orphan faces (on splitting-plane nodes above target depth)
-			if (!orphan_indices.empty()) {
-				SpatialGroup sg;
-				sg.label = "spatial_orphans";
-				for (int parsed_idx : orphan_indices) {
-					if (parsed_idx >= 0 && parsed_idx < (int)bsp_data.faces.size()) {
-						sg.face_refs.push_back({&bsp_data.faces[parsed_idx], parsed_idx});
-					}
-				}
-				if (!sg.face_refs.empty()) {
-					spatial_groups.push_back(std::move(sg));
-				}
-			}
-
-			// Sky faces are not referenced by BSP node face lists (the BSP
-			// compiler assigns them differently), so they're absent from all
-			// spatial groups above. Add them in a dedicated group here so they
-			// get meshes and write depth to occlude geometry behind sky holes.
-			{
-				SpatialGroup sg;
-				sg.label = "sky_surfaces";
-				for (const auto &fr : faces_for_model) {
-					if (goldsrc::is_sky_texture(fr.face->texture_name)) {
-						sg.face_refs.push_back(fr);
-					}
-				}
-				if (!sg.face_refs.empty()) {
-					UtilityFunctions::print("[GoldSrc] Sky surfaces group: ",
-						(int64_t)sg.face_refs.size(), " faces");
-					spatial_groups.push_back(std::move(sg));
-				}
-			}
 
 			UtilityFunctions::print("[GoldSrc] Worldspawn spatial split: ",
 				(int64_t)spatial_groups.size(), " groups from depth ",
-				(int64_t)TARGET_DEPTH, " (", (int64_t)orphan_indices.size(), " orphan faces)");
+				(int64_t)TARGET_DEPTH);
 		} else {
 			// Brush entities or fallback: single group with all faces
 			SpatialGroup sg;

--- a/src/nodes/visibility_manager.cpp
+++ b/src/nodes/visibility_manager.cpp
@@ -100,14 +100,19 @@ void VisibilityManager::_update_observer_pvs(Observer &obs, int new_leaf) {
 	if (new_leaf == obs.leaf) return;
 	obs.leaf = new_leaf;
 	int n = bsp->get_leaf_count();
+	// Leaf 0 is the GoldSrc solid/void leaf (no PVS data); leaf < 0 means fully outside
+	// the BSP. Grant full visibility in both cases so noclip players and out-of-world
+	// observers see everything rather than nothing.
+	if (new_leaf <= 0) {
+		obs.pvs.assign(n, true);
+		return;
+	}
 	obs.pvs.assign(n, false);
-	if (new_leaf >= 0) {
-		PackedInt32Array arr = bsp->get_leaf_pvs(new_leaf);
-		for (int i = 0; i < arr.size(); i++) {
-			int l = arr[i];
-			if (l >= 0 && l < n)
-				obs.pvs[l] = true;
-		}
+	PackedInt32Array arr = bsp->get_leaf_pvs(new_leaf);
+	for (int i = 0; i < arr.size(); i++) {
+		int l = arr[i];
+		if (l >= 0 && l < n)
+			obs.pvs[l] = true;
 	}
 }
 


### PR DESCRIPTION
- BSP nodes above TARGET_DEPTH no longer produce an untracked "spatial_orphans" group. Each such node's faces now get their own spatial group whose pvs_leaves = all descendant leaves, so they participate in PVS culling instead of being always-visible.

- Remove the separate sky_surfaces spatial group. Sky-textured faces are ordinary worldspawn faces collected by collect_faces_recursive through BSP node face lists, so they already land in the correct spatial groups with proper pvs_leaves. The dedicated group was duplicating them with empty pvs_leaves, keeping them always visible. Collision (WorldSkyCollision / layer 9) is unaffected — it is built from texture-name detection in the mesh loop regardless of group.

- Grant full visibility when observer leaf <= 0 (solid/void leaf or outside BSP), so noclip and out-of-world observers see everything.