### PR TITLE
Wire Android arm64 into build-all.sh

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -8,6 +8,10 @@
 #   ./build-all.sh macos        # macOS arm64 + x86_64 + universal only
 #   ./build-all.sh linux        # Linux x86_64 + arm64 only
 #   ./build-all.sh windows      # Windows x86_64 only
+#   ./build-all.sh android      # Android arm64 (Meta Quest) only
+#
+# Android requires the Android NDK. Set ANDROID_NDK or ANDROID_HOME, or install
+# it via Android Studio to a standard SDK location (auto-detected below).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -83,18 +87,34 @@ build_windows() {
     cmake_build build-windows-x86_64-release toolchain-windows-x86_64.cmake Release
 }
 
+build_android() {
+    # Locate the Android SDK/NDK if the user hasn't set ANDROID_NDK/ANDROID_HOME.
+    if [[ -z "${ANDROID_NDK:-}" && -z "${ANDROID_HOME:-}" ]]; then
+        for candidate in "$HOME/Library/Android/sdk" "$HOME/Android/Sdk" "$HOME/Android/sdk"; do
+            if [[ -d "$candidate/ndk" ]]; then
+                export ANDROID_HOME="$candidate"
+                break
+            fi
+        done
+    fi
+    cmake_build build-android-arm64-debug   toolchain-android-arm64.cmake Debug
+    cmake_build build-android-arm64-release toolchain-android-arm64.cmake Release
+}
+
 case "$filter" in
     macos)   build_macos ;;
     linux)   build_linux ;;
     windows) build_windows ;;
+    android) build_android ;;
     all)
         build_macos
         build_linux
         build_windows
+        build_android
         ;;
     *)
         echo "Unknown target: $filter"
-        echo "Usage: $0 [macos|linux|windows|all]"
+        echo "Usage: $0 [macos|linux|windows|android|all]"
         exit 1
         ;;
 esac

--- a/cmake/toolchain-android-arm64.cmake
+++ b/cmake/toolchain-android-arm64.cmake
@@ -1,0 +1,30 @@
+# Cross-compile for Android arm64 (Meta Quest 3) using the Android NDK.
+# Requires ANDROID_NDK env var or -DANDROID_NDK=/path (e.g. ~/Library/Android/sdk/ndk/<version>).
+if(NOT DEFINED ANDROID_NDK)
+    if(DEFINED ENV{ANDROID_NDK})
+        set(ANDROID_NDK "$ENV{ANDROID_NDK}")
+    elseif(DEFINED ENV{ANDROID_HOME})
+        file(GLOB _NDK_CANDIDATES "$ENV{ANDROID_HOME}/ndk/*")
+        list(SORT _NDK_CANDIDATES)
+        list(REVERSE _NDK_CANDIDATES)
+        if(_NDK_CANDIDATES)
+            list(GET _NDK_CANDIDATES 0 ANDROID_NDK)
+        endif()
+    endif()
+endif()
+
+if(NOT ANDROID_NDK OR NOT EXISTS "${ANDROID_NDK}")
+    message(FATAL_ERROR
+        "Android NDK not found.\n"
+        "Install it via Android Studio (SDK Manager → SDK Tools → NDK) then set:\n"
+        "  export ANDROID_NDK=~/Library/Android/sdk/ndk/<version>")
+endif()
+
+set(ANDROID_ABI arm64-v8a)
+set(ANDROID_PLATFORM android-29)   # API 29 = Android 10; covers all Meta Quest devices
+set(ANDROID_STL c++_static)
+
+include("${ANDROID_NDK}/build/cmake/android.toolchain.cmake")
+
+# Override output platform name so the library is named libgoldsrc.android.*.so
+set(GOLDSRC_PLATFORM_NAME "android" CACHE STRING "" FORCE)


### PR DESCRIPTION
## Summary
Adds an `android` target to `build-all.sh` so the Meta Quest arm64 build runs alongside every other platform (and as part of `all`), instead of only being buildable by hand.

- New `build_android()` builds debug + release Quest `.so` via `toolchain-android-arm64.cmake`
- Added an `android` filter and included it in the `all` target
- Auto-detects the Android SDK/NDK from common install locations when `ANDROID_NDK`/`ANDROID_HOME` are unset

## Verification
`./build-all.sh android` ran clean (exit 0), producing both binaries:
- `libgoldsrc.android.template_debug.arm64.so` (26M)
- `libgoldsrc.android.template_release.arm64.so` (1.0M) — confirmed `ELF 64-bit ... ARM aarch64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)