### PR TITLE
fix: drop redundant macOS universal lib entries

### DIFF
--- a/addons/goldsrc/goldsrc.gdextension
+++ b/addons/goldsrc/goldsrc.gdextension
@@ -5,13 +5,10 @@ reloadable = true
 
 [libraries]
 
-macos.editor              = "res://addons/goldsrc/bin/libgoldsrc.macos.template_debug.universal.dylib"
 macos.debug.arm64         = "res://addons/goldsrc/bin/libgoldsrc.macos.template_debug.arm64.dylib"
 macos.release.arm64       = "res://addons/goldsrc/bin/libgoldsrc.macos.template_release.arm64.dylib"
 macos.debug.x86_64        = "res://addons/goldsrc/bin/libgoldsrc.macos.template_debug.x86_64.dylib"
 macos.release.x86_64      = "res://addons/goldsrc/bin/libgoldsrc.macos.template_release.x86_64.dylib"
-macos.debug.universal     = "res://addons/goldsrc/bin/libgoldsrc.macos.template_debug.universal.dylib"
-macos.release.universal   = "res://addons/goldsrc/bin/libgoldsrc.macos.template_release.universal.dylib"
 
 windows.debug.x86_64      = "res://addons/goldsrc/bin/libgoldsrc.windows.template_debug.x86_64.dll"
 windows.release.x86_64    = "res://addons/goldsrc/bin/libgoldsrc.windows.template_release.x86_64.dll"


### PR DESCRIPTION
goldsrc.gdextension listed both universal and per-arch macOS dylibs, causing Godot's 'Multiple libraries found' export warning. Keep per-arch only (matches hop-physics).