### PR TITLE
Comment pass: drop what-comments that just restate the code

### DIFF
--- a/addons/goldsrc/importer/bsp_importer.gd
+++ b/addons/goldsrc/importer/bsp_importer.gd
@@ -81,7 +81,6 @@ func _import(source_file: String, save_path: String, options: Dictionary,
 	var scale_factor: float = options.get("scale_factor", 0.025)
 	var model_directory: String = options.get("model_directory", "")
 
-	# Create the BSP node and configure it
 	var bsp := GoldSrcBSP.new()
 	bsp.set_scale_factor(scale_factor)
 
@@ -102,7 +101,6 @@ func _import(source_file: String, save_path: String, options: Dictionary,
 		else:
 			push_warning("BSP Importer: Could not open WAD directory '%s'" % wad_directory)
 
-	# Load and build the BSP
 	bsp.load_bsp(source_file)
 	bsp.build_mesh()
 
@@ -128,7 +126,6 @@ func _import(source_file: String, save_path: String, options: Dictionary,
 
 	_set_owner_recursive(root, root)
 
-	# Pack and save
 	var scene := PackedScene.new()
 	var pack_err := scene.pack(root)
 	if pack_err != OK:

--- a/src/nodes/goldsrc_mdl.cpp
+++ b/src/nodes/goldsrc_mdl.cpp
@@ -382,7 +382,6 @@ void GoldSrcMDL::build_hitboxes() {
 void GoldSrcMDL::build_meshes() {
 	const auto &mdl = parser->get_data();
 
-	// Create textures
 	vector<Ref<ImageTexture>> godot_textures;
 	vector<Ref<StandardMaterial3D>> materials;
 
@@ -513,7 +512,6 @@ void GoldSrcMDL::build_meshes() {
 
 			arr_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
 
-			// Apply material
 			int skin_ref = mesh.skin_ref;
 			int tex_idx = skin_ref;
 			if (tex_idx >= 0 && tex_idx < (int)mdl.skin_table.size()) {

--- a/src/nodes/goldsrc_wad.cpp
+++ b/src/nodes/goldsrc_wad.cpp
@@ -52,7 +52,6 @@ Ref<ImageTexture> GoldSrcWAD::get_texture(const String &name) const {
 
 	string sname = str_to_lower(string(name.utf8().get_data()));
 
-	// Check cache
 	auto it = texture_cache.find(sname);
 	if (it != texture_cache.end()) {
 		return it->second;

--- a/tools/batch_convert_bsp.gd
+++ b/tools/batch_convert_bsp.gd
@@ -78,7 +78,6 @@ func _convert_one(bsp_path: String, wads: Array[GoldSrcWAD],
 		use_shader: bool, overbright: float, do_rotate: bool) -> bool:
 	var t0 := Time.get_ticks_msec()
 
-	# Create and configure GoldSrcBSP
 	var bsp := GoldSrcBSP.new()
 	bsp.set_scale_factor(scale)
 	if bsp.has_method("set_shader_lightstyles"):


### PR DESCRIPTION
Removes 7 inline comments across 4 files that narrate the following line
(`// Create textures`, `// Apply material`, `// Check cache`, `# Load and build
the BSP`, `# Pack and save`, `# Create and configure GoldSrcBSP`) — the code
already says the *what*.

Kept everything carrying *why*: GoldSrc↔Godot coord conversions with formulas,
format specifics (`// Read palette (256 colors, 3 bytes each)`), rationale
(`// Skip sky faces — not solid, projectiles pass through`), and algorithm-step
labels that structure dense code (shelf packing, lightmap passes, entity-string
parser steps).

Deletion-only — no code changes, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVXtcWnaQh1RbJ8onacGud