### PR TITLE
tests: add an in-engine suite harness, modelled on goldnet's

### DIFF
--- a/tests/ingame/main.gd
+++ b/tests/ingame/main.gd
@@ -1,0 +1,93 @@
+extends Node
+## Runner for the in-engine suites. Discovers every `suites/suite_*.gd`, runs it, and exits
+## non-zero if anything failed. See run.sh.
+##
+## Unlike goldnet's equivalent this is NOT a standalone project: it runs against the repo
+## root so res://addons/goldsrc (the GDExtension under test) and res://maps resolve exactly
+## as they do in the real project. That is the whole point — these suites exercise the
+## Godot-facing node classes, which cannot be reached from the standalone C++ tests.
+##
+##   godot --headless --path <repo root> res://tests/ingame/main.tscn
+##   godot --headless --path <repo root> res://tests/ingame/main.tscn -- --suite bsp_query
+
+const SUITE_DIR := "res://tests/ingame/suites"
+
+
+func _ready() -> void:
+	# A missing extension is the one failure that would otherwise look like a pile of
+	# unrelated parse errors, so say it plainly and stop.
+	if not ClassDB.class_exists("GoldSrcBSP"):
+		_bail("GoldSrcBSP missing — the goldsrc GDExtension did not load. Build it with ./build.sh")
+		return
+
+	var args := OS.get_cmdline_user_args()
+	var only := ""
+	var si := args.find("--suite")
+	if si != -1 and si + 1 < args.size():
+		only = args[si + 1]
+
+	var paths := _discover(only)
+	if paths.is_empty():
+		_bail("no suites found in %s%s" % [SUITE_DIR, "" if only.is_empty() else " matching '%s'" % only])
+		return
+
+	var total_checks := 0
+	var total_failures := 0
+
+	for path in paths:
+		var suite: RefCounted = (load(path) as GDScript).new()
+		suite.run()
+		suite.cleanup()
+
+		var fails: Array = suite.failures()
+		var count: int = suite.check_count()
+		total_checks += count
+		total_failures += fails.size()
+
+		# A suite that ran zero checks is a silent pass — the failure mode where a file is
+		# added but never wired up (a missing `run()` override, an early return) and the
+		# runner cheerfully reports green. Treat it as a failure of the suite itself.
+		if count == 0:
+			print("FAIL %s: ran 0 checks — is run() overridden?" % suite.suite_name())
+			total_failures += 1
+			continue
+
+		if fails.is_empty():
+			print("PASS %s (%d checks)" % [suite.suite_name(), count])
+		else:
+			print("FAIL %s (%d of %d checks failed)" % [suite.suite_name(), fails.size(), count])
+			for f in fails:
+				print("  FAIL: %s" % f)
+
+	print("")
+	if total_failures == 0:
+		print("ingame: %d checks passed across %d suite(s)" % [total_checks, paths.size()])
+		get_tree().quit(0)
+	else:
+		print("ingame: %d of %d checks failed across %d suite(s)" % [total_failures, total_checks, paths.size()])
+		get_tree().quit(1)
+
+
+## Sorted so the report order is stable run to run.
+func _discover(only: String) -> Array[String]:
+	var out: Array[String] = []
+	var dir := DirAccess.open(SUITE_DIR)
+	if dir == null:
+		return out
+	for f in dir.get_files():
+		# A bare --path run reads scripts straight off disk, but an exported/imported project
+		# would list them as .remap — accept both so this doesn't depend on the import state.
+		var suite_file := f.trim_suffix(".remap")
+		if not suite_file.begins_with("suite_") or not suite_file.ends_with(".gd"):
+			continue
+		if not only.is_empty() and suite_file != "suite_%s.gd" % only:
+			continue
+		out.append("%s/%s" % [SUITE_DIR, suite_file])
+	out.sort()
+	return out
+
+
+func _bail(msg: String) -> void:
+	push_error("[ingame runner] %s" % msg)
+	print("FAIL: %s" % msg)
+	get_tree().quit(1)

--- a/tests/ingame/main.tscn
+++ b/tests/ingame/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/ingame/main.gd" id="1"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1")

--- a/tests/ingame/run.sh
+++ b/tests/ingame/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# Run goldsrc's in-engine suites: the Godot-facing node classes (GoldSrcBSP, GoldSrcSPR,
+# GoldSrcMDL, GoldSrcWAD, VisibilityManager), which the standalone C++ tests in tests/
+# cannot reach because they need a running engine.
+#
+# Usage:
+#   ./run.sh                # all suites
+#   ./run.sh bsp_query      # just suites/suite_bsp_query.gd
+#
+# Override the engine with GODOT=/path/to/Godot. Requires ../../build.sh to have been run
+# — without the built extension the runner stops at "GoldSrcBSP missing".
+#
+# Deliberately parallel to goldnet-godot/tests/gdscript/run.sh; edit both together.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# The suites run against the repo root, not against tests/ingame, so that res://addons and
+# res://maps resolve the same way they do in the real project.
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# A wedged run must not hang CI. macOS has no coreutils `timeout`, so this is rolled by
+# hand. It is load-bearing rather than defensive: a GDScript parse error leaves headless
+# Godot running with no main loop and no output, forever.
+TIMEOUT_S="${TIMEOUT_S:-120}"
+
+GODOT="${GODOT:-}"
+if [ -z "$GODOT" ] || [ ! -x "$GODOT" ]; then
+    for candidate in \
+        "/Applications/Godot.app/Contents/MacOS/Godot" \
+        "$HOME/Applications/Godot.app/Contents/MacOS/Godot" \
+        "$(command -v godot 2>/dev/null || true)"; do
+        if [ -n "$candidate" ] && [ -x "$candidate" ]; then GODOT="$candidate"; break; fi
+    done
+fi
+if [ ! -x "${GODOT:-}" ]; then
+    echo "Godot binary not found. Set GODOT=/path/to/Godot" >&2
+    exit 127
+fi
+
+ARGS=(--headless --path "$PROJECT_DIR" res://tests/ingame/main.tscn)
+if [ $# -gt 0 ]; then
+    ARGS+=(-- --suite "$1")
+fi
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+"$GODOT" "${ARGS[@]}" > "$log" 2>&1 &
+pid=$!
+
+waited=0
+while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$TIMEOUT_S" ]; then
+        echo "  (watchdog: killing the run after ${TIMEOUT_S}s)"
+        kill -9 "$pid" 2>/dev/null
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+wait "$pid" 2>/dev/null
+rc=$?
+
+# Godot writes its banner, the extension's own load chatter and any engine errors here
+# too; show only the suite report on success, and everything on failure.
+if [ "$rc" -eq 0 ]; then
+    grep -E "^(PASS|ingame:)" "$log"
+else
+    sed 's/^/  | /' "$log"
+    echo ""
+    echo "ingame suites FAILED (exit $rc)"
+fi
+exit "$rc"

--- a/tests/ingame/suite.gd
+++ b/tests/ingame/suite.gd
@@ -1,0 +1,113 @@
+extends RefCounted
+## Base for the in-engine suites.
+##
+## Deliberately parallel to goldnet-godot's tests/gdscript/suite.gd — same assertion names
+## and same reporting contract, so the two repos' harnesses read alike. Keep them in step.
+##
+## No `class_name` on purpose: global class names resolve from a cache the editor writes
+## during an import pass, which a bare `--headless --path` run doesn't perform. Suites
+## `extends "res://tests/ingame/suite.gd"` by path so this works from a clean checkout with
+## no editor step. The classes under test (GoldSrcBSP and friends) are GDExtension classes
+## registered at engine start, not script classes, so those resolve as bare identifiers.
+##
+## Suites override `run()` and call the assertions below. Assertions accumulate rather than
+## abort, so one run reports everything wrong instead of only the first failure.
+
+## The one real map in the repo. Every geometry assertion is anchored to this file, so
+## replacing it means re-deriving the numbers that reference it.
+const MAP_PATH := "res://maps/ww_2fort.bsp"
+const SPRITE_PATH := "res://sprites/fire.spr"
+
+## GoldSrc leaf contents. Not exported to GDScript by the extension, so they are restated
+## here; they are format constants and will not move.
+const CONTENTS_EMPTY := -1
+const CONTENTS_SOLID := -2
+const CONTENTS_WATER := -3
+const CONTENTS_SKY := -6
+
+var _failures: Array[String] = []
+var _checks: int = 0
+var _to_free: Array[Node] = []
+
+
+## Override with the suite's tests.
+func run() -> void:
+	pass
+
+
+## Human-readable suite name, used in the report. Defaults to the script's filename.
+func suite_name() -> String:
+	return (get_script() as GDScript).resource_path.get_file().get_basename()
+
+
+# --- helpers ---
+
+## Node-derived GoldSrc classes are not refcounted, so anything a suite creates has to be
+## freed or the run ends with "ObjectDB instances leaked at exit". Hand them to this and
+## the runner disposes of them after run() returns.
+func track(n: Node) -> Node:
+	_to_free.append(n)
+	return n
+
+
+## Loads the shared map into a tracked GoldSrcBSP, failing the suite if it will not parse.
+## Returns null on failure so callers can bail out rather than assert against a blank node.
+func load_map() -> GoldSrcBSP:
+	var bsp := GoldSrcBSP.new()
+	track(bsp)
+	var err := bsp.load_bsp(MAP_PATH)
+	if err != OK:
+		fail("could not load %s (error %d)" % [MAP_PATH, err])
+		return null
+	return bsp
+
+
+func cleanup() -> void:
+	for n in _to_free:
+		if is_instance_valid(n):
+			n.free()
+	_to_free.clear()
+
+
+# --- assertions ---
+
+func check(cond: bool, msg: String) -> bool:
+	_checks += 1
+	if not cond:
+		_failures.append(msg)
+	return cond
+
+
+func check_eq(got: Variant, want: Variant, msg: String) -> bool:
+	return check(got == want, "%s (got %s, want %s)" % [msg, got, want])
+
+
+## Inclusive on both ends.
+func check_between(got: float, lo: float, hi: float, msg: String) -> bool:
+	return check(got >= lo and got <= hi,
+		"%s (got %s, want %s..%s)" % [msg, got, lo, hi])
+
+
+func check_near(got: float, want: float, tol: float, msg: String) -> bool:
+	return check(absf(got - want) <= tol,
+		"%s (got %f, want %f, tol %f)" % [msg, got, want, tol])
+
+
+func check_near_v(got: Vector3, want: Vector3, tol: float, msg: String) -> bool:
+	return check(got.distance_to(want) <= tol,
+		"%s (got %.4v, want %.4v, tol %f)" % [msg, got, want, tol])
+
+
+func fail(msg: String) -> void:
+	_checks += 1
+	_failures.append(msg)
+
+
+# --- harness plumbing ---
+
+func failures() -> Array[String]:
+	return _failures
+
+
+func check_count() -> int:
+	return _checks

--- a/tests/ingame/suites/suite_bsp_entities.gd
+++ b/tests/ingame/suites/suite_bsp_entities.gd
@@ -1,0 +1,66 @@
+extends "res://tests/ingame/suite.gd"
+## Entity extraction. The entity lump is how a map tells the game where players spawn, what
+## the sky is and which WADs it needs, so this is the parser output the game leans on most.
+
+
+func run() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	var ents: Array = bsp.get_entities()
+	_worldspawn(ents)
+	_every_entity_is_well_formed(ents)
+	_player_spawns(ents)
+
+
+## Entity 0 is worldspawn by format definition, and carries the map-wide settings.
+func _worldspawn(ents: Array) -> void:
+	if ents.is_empty():
+		fail("no entities parsed")
+		return
+
+	var ws: Dictionary = ents[0]
+	check_eq(ws.get("classname", ""), "worldspawn", "entity 0 is worldspawn")
+	check_eq(ws.get("skyname", ""), "wiz", "worldspawn carries ww_2fort's skyname")
+	check(ws.has("wad"), "worldspawn lists its WAD dependencies")
+	# Keys with backslashes and semicolons survive intact — the wad list is the one field
+	# where escaping mistakes would show up.
+	check(String(ws.get("wad", "")).contains("halflife.wad"),
+		"the WAD list keeps its path separators")
+
+
+func _every_entity_is_well_formed(ents: Array) -> void:
+	var missing_classname := 0
+	var not_a_dict := 0
+	for e in ents:
+		if typeof(e) != TYPE_DICTIONARY:
+			not_a_dict += 1
+			continue
+		if not (e as Dictionary).has("classname"):
+			missing_classname += 1
+	check_eq(not_a_dict, 0, "every entity is a Dictionary")
+	check_eq(missing_classname, 0, "every entity has a classname")
+
+
+func _player_spawns(ents: Array) -> void:
+	var spawns: Array = []
+	var solo_starts := 0
+	for e in ents:
+		match String((e as Dictionary).get("classname", "")):
+			"info_player_teamspawn":
+				spawns.append(e)
+			"info_player_start":
+				solo_starts += 1
+
+	# 24 team spawns plus a single info_player_start. Matched exactly rather than by an
+	# "info_player" prefix, which conflates the two and gives 25.
+	check_eq(spawns.size(), 24, "ww_2fort's team spawn count")
+	check_eq(solo_starts, 1, "ww_2fort has one non-team start")
+	if spawns.is_empty():
+		return
+
+	var first: Dictionary = spawns[0]
+	check_eq(first.get("origin", ""), "1435 1626 242", "first team spawn origin")
+	check_eq(first.get("team_no", ""), "1", "first team spawn belongs to team 1")
+	check(first.has("angles"), "a spawn carries a facing angle")

--- a/tests/ingame/suites/suite_bsp_load.gd
+++ b/tests/ingame/suites/suite_bsp_load.gd
@@ -1,0 +1,81 @@
+extends "res://tests/ingame/suite.gd"
+## GoldSrcBSP loading: the two entry points, what an unloaded node reports, and what each
+## rejection path returns.
+##
+## The counts below are anchored to the shipped maps/ww_2fort.bsp. They are exact on
+## purpose — a parser change that quietly alters how many faces or leafs a real map yields
+## is precisely the regression the standalone C++ tests, built on synthetic fixtures,
+## cannot see.
+
+
+func run() -> void:
+	_unloaded_node_is_inert()
+	_loads_the_shipped_map()
+	_rejection_paths()
+	_both_entry_points_agree()
+
+
+## Every accessor must be safe before a map is loaded — these are public API and callers
+## reach for them before checking.
+func _unloaded_node_is_inert() -> void:
+	var bsp := GoldSrcBSP.new()
+	track(bsp)
+
+	check_eq(bsp.get_leaf_count(), 0, "unloaded: leaf count")
+	check_eq(bsp.get_entities().size(), 0, "unloaded: entity count")
+	check_eq(bsp.get_pvs_blob().size(), 0, "unloaded: PVS blob is empty")
+	check_eq(bsp.get_leaf_pvs(0).size(), 0, "unloaded: leaf PVS is empty")
+	check_eq(bsp.point_contents(Vector3.ZERO), CONTENTS_EMPTY,
+		"unloaded: everywhere reads as empty space")
+	check_eq(bsp.point_to_leaf(Vector3.ZERO), -1, "unloaded: no leaf contains a point")
+
+
+func _loads_the_shipped_map() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	check_eq(bsp.get_leaf_count(), 3488, "ww_2fort leaf count")
+	check_eq(bsp.get_entities().size(), 643, "ww_2fort entity count")
+	check(bsp.get_pvs_blob().size() > 0, "a loaded map exposes a PVS blob")
+
+
+func _rejection_paths() -> void:
+	var bsp := GoldSrcBSP.new()
+	track(bsp)
+
+	check_eq(bsp.load_bsp("res://maps/does_not_exist.bsp"), ERR_FILE_NOT_FOUND,
+		"missing file is reported as not found")
+	check_eq(bsp.load_bsp_from_data(PackedByteArray()), ERR_INVALID_DATA,
+		"empty buffer is rejected as invalid")
+
+	var junk := PackedByteArray()
+	junk.resize(256) # zeroed: right size to be a header, wrong version
+	check_eq(bsp.load_bsp_from_data(junk), ERR_PARSE_ERROR,
+		"a buffer that is not a BSP is rejected as a parse error")
+
+	# A failed load must not leave half-parsed state behind.
+	check_eq(bsp.get_leaf_count(), 0, "after a failed load the node is still empty")
+
+
+## load_bsp is load_bsp_from_data plus a file read, so the two must agree on the same
+## bytes. Cheap to state, and it pins the file-reading path against the in-memory one.
+func _both_entry_points_agree() -> void:
+	var from_path := load_map()
+	if from_path == null:
+		return
+
+	var f := FileAccess.open(MAP_PATH, FileAccess.READ)
+	if f == null:
+		fail("could not read %s for the in-memory comparison" % MAP_PATH)
+		return
+	var bytes := f.get_buffer(f.get_length())
+	f.close()
+
+	var from_data := GoldSrcBSP.new()
+	track(from_data)
+	check_eq(from_data.load_bsp_from_data(bytes), OK, "the same bytes load from memory")
+	check_eq(from_data.get_leaf_count(), from_path.get_leaf_count(),
+		"both entry points agree on leaf count")
+	check_eq(from_data.get_entities().size(), from_path.get_entities().size(),
+		"both entry points agree on entity count")

--- a/tests/ingame/suites/suite_bsp_mesh.gd
+++ b/tests/ingame/suites/suite_bsp_mesh.gd
@@ -1,0 +1,92 @@
+extends "res://tests/ingame/suite.gd"
+## build_mesh: the 3,500-line half of goldsrc_bsp.cpp that turns parsed faces into a Godot
+## scene tree. Nothing outside an engine can call it at all, which is the reason this
+## harness exists.
+
+
+func run() -> void:
+	_scale_factor()
+	_builds_a_scene_tree()
+	_is_idempotent()
+	_face_axes()
+
+
+func _scale_factor() -> void:
+	var bsp := GoldSrcBSP.new()
+	track(bsp)
+
+	check_near(bsp.get_scale_factor(), 0.025, 1e-6,
+		"default scale is the GoldSrc-to-metres factor")
+	bsp.set_scale_factor(0.5)
+	check_near(bsp.get_scale_factor(), 0.5, 1e-6, "scale factor round-trips")
+	bsp.set_scale_factor(0.025)
+
+
+func _builds_a_scene_tree() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	check_eq(bsp.get_child_count(), 0, "nothing is built until build_mesh is called")
+	bsp.build_mesh()
+
+	# One child per entity: worldspawn plus every brush entity.
+	check_eq(bsp.get_child_count(), 643, "build_mesh emits a node per entity")
+
+	var worldspawn := bsp.get_node_or_null("worldspawn")
+	check(worldspawn != null, "worldspawn is present by name")
+	if worldspawn != null:
+		check(worldspawn.get_child_count() > 0,
+			"worldspawn is split into spatial groups")
+
+	var stats := _walk(bsp)
+	check(stats.meshes > 0, "the tree contains MeshInstance3D nodes (got %d)" % stats.meshes)
+	check_eq(stats.meshes_without_surfaces, 0,
+		"every emitted mesh has at least one surface")
+	check(stats.bodies > 0,
+		"the tree contains collision bodies (got %d)" % stats.bodies)
+
+
+## Rebuilding must replace the tree, not append to it. Getting this wrong doubles a map's
+## geometry every time a level reloads, which is invisible until frame rate collapses.
+func _is_idempotent() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	bsp.build_mesh()
+	var first := bsp.get_child_count()
+	bsp.build_mesh()
+	check_eq(bsp.get_child_count(), first, "building twice does not duplicate the tree")
+
+
+## get_face_axes returns the texture S and T axes for the face under a point, used to align
+## decals. Two vectors, always.
+func _face_axes() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	var axes: Array = bsp.get_face_axes(Vector3(-35.875, 6.05, 40.65), Vector3(0, 1, 0))
+	check_eq(axes.size(), 2, "face axes come back as an S/T pair")
+	if axes.size() == 2:
+		check(axes[0] is Vector3 and axes[1] is Vector3, "both axes are Vector3")
+		check_near((axes[0] as Vector3).length(), 1.0, 0.01, "the S axis is unit length")
+		check_near((axes[1] as Vector3).length(), 1.0, 0.01, "the T axis is unit length")
+
+
+func _walk(root: Node) -> Dictionary:
+	var out := {"meshes": 0, "meshes_without_surfaces": 0, "bodies": 0}
+	var stack: Array[Node] = [root]
+	while not stack.is_empty():
+		var n: Node = stack.pop_back()
+		if n is MeshInstance3D:
+			out.meshes += 1
+			var m: Mesh = (n as MeshInstance3D).mesh
+			if m == null or m.get_surface_count() == 0:
+				out.meshes_without_surfaces += 1
+		if n.is_class("StaticBody3D"):
+			out.bodies += 1
+		for c in n.get_children():
+			stack.append(c)
+	return out

--- a/tests/ingame/suites/suite_bsp_query.gd
+++ b/tests/ingame/suites/suite_bsp_query.gd
@@ -1,0 +1,111 @@
+extends "res://tests/ingame/suite.gd"
+## The spatial queries gameplay depends on: point_contents, point_to_leaf, the PVS, and
+## AABB leaf gathering. A regression here is a live bug — players falling through floors or
+## geometry vanishing — rather than something that fails loudly at load time.
+
+## The first info_player_teamspawn in ww_2fort, at GoldSrc (1435 1626 242), converted with
+## the extension's own mapping: godot = (-x*s, z*s, y*s) at the default scale of 0.025.
+## Hardcoded rather than read from the entity list so a failure here means a query bug, not
+## an entity-parsing bug — that is asserted separately in suite_bsp_entities.
+const SPAWN := Vector3(-35.875, 6.05, 40.65)
+
+
+func run() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	_contents_around_a_spawn(bsp)
+	_contents_over_a_grid(bsp)
+	_point_to_leaf(bsp)
+	_pvs(bsp)
+	_leaves_in_aabb(bsp)
+
+
+## A player spawn is by construction standing in open space on top of solid floor. If this
+## ever inverts, players are spawning inside geometry.
+func _contents_around_a_spawn(bsp: GoldSrcBSP) -> void:
+	check_eq(bsp.point_contents(SPAWN), CONTENTS_EMPTY,
+		"a player spawn stands in empty space")
+	check_eq(bsp.point_contents(SPAWN - Vector3(0, 5, 0)), CONTENTS_SOLID,
+		"there is solid floor beneath a player spawn")
+
+	# Far outside the map is the void. Whatever it reports, it must be a real contents
+	# value and must not crash the node walk.
+	var far := bsp.point_contents(Vector3(1e6, 1e6, 1e6))
+	check(far in [CONTENTS_EMPTY, CONTENTS_SOLID, CONTENTS_WATER, CONTENTS_SKY],
+		"a point far outside the map yields a known contents value (got %d)" % far)
+
+
+## Two sample points are not a net. A fixed grid across the map pins the whole
+## point-to-leaf walk: an off-by-one in the leaf-index decode, a swapped node child or a
+## dropped axis all move these counts, where a pair of hand-picked points can easily land
+## on neighbours that happen to agree.
+##
+## The totals are anchored to the shipped ww_2fort.bsp. If they change, either the map
+## changed or the BSP walk did — both worth a human look rather than a silent re-baseline.
+func _contents_over_a_grid(bsp: GoldSrcBSP) -> void:
+	var solid := 0
+	var empty := 0
+	var other := 0
+
+	for ix in range(12):
+		for iy in range(6):
+			for iz in range(12):
+				var p := Vector3(-60.0 + ix * 10.0, 2.0 + iy * 6.0, -60.0 + iz * 10.0)
+				match bsp.point_contents(p):
+					CONTENTS_SOLID: solid += 1
+					CONTENTS_EMPTY: empty += 1
+					_: other += 1
+
+	check_eq(solid + empty + other, 864, "the grid samples every point")
+	check_eq(solid, 756, "solid sample count across ww_2fort")
+	check_eq(empty, 108, "open-space sample count across ww_2fort")
+
+
+func _point_to_leaf(bsp: GoldSrcBSP) -> void:
+	var leaf := bsp.point_to_leaf(SPAWN)
+	check_between(leaf, 0, bsp.get_leaf_count() - 1,
+		"a spawn resolves to a leaf inside the map")
+
+	# The same point must land in the same leaf every time — the walk is pure.
+	check_eq(bsp.point_to_leaf(SPAWN), leaf, "point_to_leaf is deterministic")
+
+
+func _pvs(bsp: GoldSrcBSP) -> void:
+	var leaf := bsp.point_to_leaf(SPAWN)
+	var pvs: PackedInt32Array = bsp.get_leaf_pvs(leaf)
+
+	check(pvs.size() > 0, "a spawn's leaf can see something")
+	check(leaf in pvs, "a leaf is visible from itself")
+
+	var leaf_count := bsp.get_leaf_count()
+	var out_of_range := 0
+	for i in pvs:
+		if i < 0 or i >= leaf_count:
+			out_of_range += 1
+	check_eq(out_of_range, 0, "every PVS entry is a valid leaf index")
+
+	check_eq(bsp.get_leaf_pvs(-1).size(), 0, "PVS of a negative leaf is empty")
+	check_eq(bsp.get_leaf_pvs(leaf_count).size(), 0, "PVS past the last leaf is empty")
+
+
+func _leaves_in_aabb(bsp: GoldSrcBSP) -> void:
+	var leaf_count := bsp.get_leaf_count()
+
+	var everything := bsp.get_leaves_in_aabb(
+		AABB(Vector3(-10000, -10000, -10000), Vector3(20000, 20000, 20000)))
+	check(everything.size() > 0, "an all-encompassing AABB gathers leaves")
+
+	# The interesting property is not how many come back but that none of them is a bogus
+	# index — an out-of-range leaf here would be read straight into a lookup by callers.
+	var bad := 0
+	for i in everything:
+		if i < 0 or i >= leaf_count:
+			bad += 1
+	check_eq(bad, 0, "every gathered leaf index is in range")
+
+	var at_spawn := bsp.get_leaves_in_aabb(AABB(SPAWN - Vector3.ONE, Vector3.ONE * 2.0))
+	check(at_spawn.size() > 0, "a small AABB at a spawn gathers at least one leaf")
+	check(at_spawn.size() < everything.size(),
+		"a small AABB gathers fewer leaves than the whole map")

--- a/tests/ingame/suites/suite_lightstyles.gd
+++ b/tests/ingame/suites/suite_lightstyles.gd
@@ -1,0 +1,52 @@
+extends "res://tests/ingame/suite.gd"
+## Lightstyle animation: the per-style brightness table GoldSrc uses for flickering and
+## pulsing lights. Indices come straight from map data, so out-of-range access has to be
+## safe rather than merely unlikely.
+
+
+func run() -> void:
+	var bsp := load_map()
+	if bsp == null:
+		return
+
+	_defaults(bsp)
+	_round_trips(bsp)
+	_out_of_range_is_safe(bsp)
+	_shader_toggle(bsp)
+
+
+func _defaults(bsp: GoldSrcBSP) -> void:
+	check_near(bsp.get_lightstyle(0), 1.0, 1e-6, "style 0 defaults to full brightness")
+
+
+func _round_trips(bsp: GoldSrcBSP) -> void:
+	bsp.set_lightstyle(3, 0.42)
+	check_near(bsp.get_lightstyle(3), 0.42, 1e-5, "a set style reads back")
+
+	bsp.set_lightstyle(3, 0.0)
+	check_near(bsp.get_lightstyle(3), 0.0, 1e-6, "a style can be driven to zero")
+
+	# Styles are independent — writing one must not disturb another.
+	check_near(bsp.get_lightstyle(0), 1.0, 1e-6, "style 0 is untouched by writes to style 3")
+	bsp.set_lightstyle(3, 1.0)
+
+
+func _out_of_range_is_safe(bsp: GoldSrcBSP) -> void:
+	check_near(bsp.get_lightstyle(9999), 0.0, 1e-6, "a style past the table reads as zero")
+	check_near(bsp.get_lightstyle(-1), 0.0, 1e-6, "a negative style reads as zero")
+
+	# The assertion is that these do not crash or corrupt the table; the engine keeps
+	# running and neighbouring styles keep their values.
+	bsp.set_lightstyle(9999, 0.5)
+	bsp.set_lightstyle(-1, 0.5)
+	check_near(bsp.get_lightstyle(0), 1.0, 1e-6,
+		"out-of-range writes leave the real table intact")
+
+
+func _shader_toggle(bsp: GoldSrcBSP) -> void:
+	var was := bsp.get_shader_lightstyles()
+	check(was, "shader lightstyles are on by default")
+
+	bsp.set_shader_lightstyles(false)
+	check_eq(bsp.get_shader_lightstyles(), false, "the shader lightstyle flag round-trips")
+	bsp.set_shader_lightstyles(was)

--- a/tests/ingame/suites/suite_mdl_wad.gd
+++ b/tests/ingame/suites/suite_mdl_wad.gd
@@ -1,0 +1,51 @@
+extends "res://tests/ingame/suite.gd"
+## GoldSrcMDL and GoldSrcWAD.
+##
+## The repo ships no .mdl or .wad, so this covers what can be asserted without one: that a
+## fresh node reports empty rather than garbage, that every accessor is safe before a load,
+## and that a failed load is reported and leaves nothing behind. The parsing itself is
+## covered by the standalone C++ suite, which builds its own fixtures.
+##
+## If a small .mdl and .wad are ever added to the repo, this is where the round-trip
+## assertions belong — bone counts, sequence names, texture lookup by name.
+
+
+func run() -> void:
+	_mdl_unloaded()
+	_wad_unloaded()
+
+
+func _mdl_unloaded() -> void:
+	var mdl := GoldSrcMDL.new()
+	track(mdl)
+
+	check_eq(mdl.get_sequence_count(), 0, "unloaded MDL has no sequences")
+	check_eq(mdl.get_bone_count(), 0, "unloaded MDL has no bones")
+	check_eq(mdl.get_bodypart_count(), 0, "unloaded MDL has no bodyparts")
+	check_eq(mdl.get_skin_count(), 0, "unloaded MDL has no skins")
+
+	# Indexed accessors on an empty model must not read past the end.
+	check_eq(mdl.get_sequence_name(0), "", "sequence name of an absent sequence is empty")
+	check_eq(mdl.get_sequence_name(-1), "", "sequence name of a negative index is empty")
+	check_eq(mdl.get_bodypart_name(0), "", "bodypart name of an absent part is empty")
+
+	check_eq(mdl.load_mdl("res://models/does_not_exist.mdl"), ERR_FILE_NOT_FOUND,
+		"a missing model is reported as not found")
+	check_eq(mdl.get_bone_count(), 0, "a failed load leaves the model empty")
+
+	check_near(mdl.get_scale_factor(), 0.025, 1e-6, "MDL shares the world scale factor")
+	mdl.set_scale_factor(0.1)
+	check_near(mdl.get_scale_factor(), 0.1, 1e-6, "MDL scale factor round-trips")
+
+
+func _wad_unloaded() -> void:
+	var wad := GoldSrcWAD.new()
+
+	check_eq(wad.get_texture_count(), 0, "unloaded WAD has no textures")
+	check_eq(wad.get_texture_names().size(), 0, "unloaded WAD lists no names")
+	check_eq(wad.has_texture("anything"), false, "unloaded WAD contains nothing")
+	check(wad.get_texture("anything") == null, "unloaded WAD returns no texture")
+
+	check_eq(wad.load_wad("res://wads/does_not_exist.wad"), ERR_FILE_NOT_FOUND,
+		"a missing WAD is reported as not found")
+	check_eq(wad.get_texture_count(), 0, "a failed load leaves the WAD empty")

--- a/tests/ingame/suites/suite_spr.gd
+++ b/tests/ingame/suites/suite_spr.gd
@@ -1,0 +1,54 @@
+extends "res://tests/ingame/suite.gd"
+## GoldSrcSPR against the shipped sprites/fire.spr. Unlike the BSP suites this exercises
+## the Resource-derived side of the extension, including texture creation, which only
+## exists inside an engine.
+
+
+func run() -> void:
+	_unloaded_is_inert()
+	_loads_the_shipped_sprite()
+	_frame_access_is_bounds_checked()
+
+
+func _unloaded_is_inert() -> void:
+	var spr := GoldSrcSPR.new()
+	check_eq(spr.get_frame_count(), 0, "unloaded sprite has no frames")
+	check_eq(spr.load_spr("res://sprites/does_not_exist.spr"), ERR_FILE_NOT_FOUND,
+		"a missing sprite is reported as not found")
+
+
+func _loads_the_shipped_sprite() -> void:
+	var spr := GoldSrcSPR.new()
+	check_eq(spr.load_spr(SPRITE_PATH), OK, "fire.spr loads")
+	check_eq(spr.get_frame_count(), 15, "fire.spr frame count")
+
+	# 4 = SPR_VP_PARALLEL_ORIENTED, 1 = SPR_ADDITIVE. Both come from the file header and
+	# decide how the sprite is drawn, so a misread here changes rendering silently.
+	check_eq(spr.get_type(), 4, "fire.spr orientation type")
+	check_eq(spr.get_texture_format(), 1, "fire.spr is additive")
+
+	var tex: Texture2D = spr.get_frame_texture(0)
+	check(tex != null, "frame 0 produces a texture")
+	if tex != null:
+		check_eq(tex.get_size(), Vector2(32, 96), "frame 0 dimensions")
+
+	check_eq(spr.get_frame_origin(0), Vector2i(-16, 48), "frame 0 origin")
+
+	# Every frame must produce a usable texture, not just the first.
+	var missing := 0
+	for i in spr.get_frame_count():
+		if spr.get_frame_texture(i) == null:
+			missing += 1
+	check_eq(missing, 0, "every frame produces a texture")
+
+
+func _frame_access_is_bounds_checked() -> void:
+	var spr := GoldSrcSPR.new()
+	if spr.load_spr(SPRITE_PATH) != OK:
+		fail("could not load %s" % SPRITE_PATH)
+		return
+
+	check(spr.get_frame_texture(999) == null, "a frame past the end has no texture")
+	check(spr.get_frame_texture(-1) == null, "a negative frame has no texture")
+	check_eq(spr.get_frame_origin(999), Vector2i(0, 0),
+		"a frame past the end has a zero origin")


### PR DESCRIPTION
Roughly four fifths of the extension is the Godot-facing node layer (`goldsrc_bsp.cpp` alone is 3,500 lines) and none of it could be reached from the standalone C++ tests — it needs a running engine. This adds the harness that provides one, parallel to goldnet-godot's `tests/gdscript`.

Seven suites, 97 checks, against the shipped `ww_2fort.bsp` and `fire.spr`: load paths, spatial queries (`point_contents`/`point_to_leaf`/PVS/AABB), entities, `build_mesh` and its idempotency, lightstyles, SPR decode, MDL/WAD failure paths.

Runs against the repo root, not a standalone project, so `res://addons` and `res://maps` resolve as in the real project — no vendored/symlinked addon copy.

Validated by mutating the C++ and rebuilding. One genuine weakness surfaced and was fixed: two sample points let an off-by-one through, so the query suite now samples an 864-point grid.

Base: `tests/bsp-parser-coverage`. Merge third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiaYzX4snMPSBLrJQbgPf3