### PR TITLE
bsp: parse Quake (v29) maps, not just Half-Life (v30)

### DIFF
--- a/src/parsers/bsp_parser.cpp
+++ b/src/parsers/bsp_parser.cpp
@@ -9,6 +9,43 @@ using namespace std;
 
 namespace goldsrc {
 
+// id Software's global Quake palette (gfx/palette.lmp), 256 RGB triples. Quake BSP (v29) textures
+// store only palette indices — unlike Half-Life, which appends a 256-colour palette to each miptex.
+static const uint8_t QUAKE_PALETTE[768] = {
+	0,0,0, 15,15,15, 31,31,31, 47,47,47, 63,63,63, 75,75,75, 91,91,91, 107,107,107,
+	123,123,123, 139,139,139, 155,155,155, 171,171,171, 187,187,187, 203,203,203, 219,219,219, 235,235,235,
+	15,11,7, 23,15,11, 31,23,11, 39,27,15, 47,35,19, 55,43,23, 63,47,23, 75,55,27,
+	83,59,27, 91,67,31, 99,75,31, 107,83,31, 115,87,31, 123,95,35, 131,103,35, 143,111,35,
+	11,11,15, 19,19,27, 27,27,39, 39,39,51, 47,47,63, 55,55,75, 63,63,87, 71,71,103,
+	79,79,115, 91,91,127, 99,99,139, 107,107,151, 115,115,163, 123,123,175, 131,131,187, 139,139,203,
+	0,0,0, 7,7,0, 11,11,0, 19,19,0, 27,27,0, 35,35,0, 43,43,7, 47,47,7,
+	55,55,7, 63,63,7, 71,71,7, 75,75,11, 83,83,11, 91,91,11, 99,99,11, 107,107,15,
+	7,0,0, 15,0,0, 23,0,0, 31,0,0, 39,0,0, 47,0,0, 55,0,0, 63,0,0,
+	71,0,0, 79,0,0, 87,0,0, 95,0,0, 103,0,0, 111,0,0, 119,0,0, 127,0,0,
+	19,19,0, 27,27,0, 35,35,0, 47,43,0, 55,47,0, 67,55,0, 75,59,7, 87,67,7,
+	95,71,7, 107,75,11, 119,83,15, 131,87,19, 139,91,19, 151,95,27, 163,99,31, 175,103,35,
+	35,19,7, 47,23,11, 59,31,15, 75,35,19, 87,43,23, 99,47,31, 115,55,35, 127,59,43,
+	143,67,51, 159,79,51, 175,99,47, 191,119,47, 207,143,43, 223,171,39, 239,203,31, 255,243,27,
+	11,7,0, 27,19,0, 43,35,15, 55,43,19, 71,51,27, 83,55,35, 99,63,43, 111,71,51,
+	127,83,63, 139,95,71, 155,107,83, 167,123,95, 183,135,107, 195,147,123, 211,163,139, 227,179,151,
+	171,139,163, 159,127,151, 147,115,135, 139,103,123, 127,91,111, 119,83,99, 107,75,87, 95,63,75,
+	87,55,67, 75,47,55, 67,39,47, 55,31,35, 43,23,27, 31,15,19, 19,11,11, 11,7,7,
+	187,115,159, 175,107,143, 163,95,131, 151,87,119, 139,79,107, 127,75,95, 115,67,83, 107,59,75,
+	95,51,63, 83,43,55, 71,35,43, 59,31,35, 47,23,27, 35,19,19, 23,11,11, 15,7,7,
+	219,195,187, 203,179,167, 191,163,155, 175,151,139, 163,135,123, 151,123,111, 135,111,95, 123,99,83,
+	107,87,71, 95,75,59, 83,63,51, 67,51,39, 55,43,31, 39,31,23, 27,19,15, 15,11,7,
+	111,131,123, 103,123,111, 95,115,103, 87,107,95, 79,99,87, 71,91,79, 63,83,71, 55,75,63,
+	47,67,55, 43,59,47, 35,51,39, 31,43,31, 23,35,23, 15,27,19, 11,19,11, 7,11,7,
+	255,243,27, 239,223,23, 219,203,19, 203,183,15, 187,167,15, 171,151,11, 155,131,7, 139,115,7,
+	123,99,7, 107,83,0, 91,71,0, 75,55,0, 59,43,0, 43,31,0, 27,15,0, 11,7,0,
+	0,0,255, 11,11,239, 19,19,223, 27,27,207, 35,35,191, 43,43,175, 47,47,159, 47,47,143,
+	47,47,127, 47,47,111, 47,47,95, 43,43,79, 35,35,63, 27,27,47, 19,19,31, 11,11,15,
+	43,0,0, 59,0,0, 75,7,0, 95,7,0, 111,15,0, 127,23,7, 147,31,7, 163,39,11,
+	183,51,15, 195,75,27, 207,99,43, 219,127,59, 227,151,79, 231,171,95, 239,191,119, 247,211,139,
+	167,123,59, 183,155,55, 199,195,55, 231,227,87, 127,191,255, 171,231,255, 215,255,255, 103,0,0,
+	139,0,0, 179,0,0, 215,0,0, 255,0,0, 255,243,147, 255,247,199, 255,255,255, 159,91,83,
+};
+
 template <typename T>
 static vector<T> read_lump(const uint8_t *data, size_t file_size, const BSPLump &lump) {
 	if (lump.fileofs < 0 || lump.filelen <= 0) return {};
@@ -21,9 +58,12 @@ bool BSPParser::parse(const uint8_t *data, size_t size) {
 
 	header = read_from<BSPHeader>(data);
 
-	if (header.version != HLBSP_VERSION) {
+	if (header.version != HLBSP_VERSION && header.version != QBSP_VERSION) {
 		return false;
 	}
+	// Quake (v29) shares HL's lump layout and geometry structs, but its textures index the global
+	// Quake palette (no embedded palette) and its lightmaps are grayscale — handled below.
+	is_quake = (header.version == QBSP_VERSION);
 
 	vertexes = read_lump<BSPVertex>(data, size, header.lumps[LUMP_VERTEXES]);
 	planes = read_lump<BSPPlane>(data, size, header.lumps[LUMP_PLANES]);
@@ -40,8 +80,21 @@ bool BSPParser::parse(const uint8_t *data, size_t size) {
 	{
 		const BSPLump &lump = header.lumps[LUMP_LIGHTING];
 		if (lump.filelen > 0 && (size_t)lump.fileofs + lump.filelen <= size) {
-			bsp_data.lighting.resize(lump.filelen);
-			memcpy(bsp_data.lighting.data(), data + lump.fileofs, lump.filelen);
+			if (is_quake) {
+				// Quake lightmaps are grayscale (1 byte/luxel). Expand to the RGB layout the rest
+				// of the pipeline expects (r=g=b=intensity); face lightofs is scaled ×3 in
+				// parse_faces to match this tripling.
+				bsp_data.lighting.resize((size_t)lump.filelen * 3);
+				const uint8_t *src = data + lump.fileofs;
+				for (int32_t j = 0; j < lump.filelen; j++) {
+					bsp_data.lighting[(size_t)j * 3 + 0] = src[j];
+					bsp_data.lighting[(size_t)j * 3 + 1] = src[j];
+					bsp_data.lighting[(size_t)j * 3 + 2] = src[j];
+				}
+			} else {
+				bsp_data.lighting.resize(lump.filelen);
+				memcpy(bsp_data.lighting.data(), data + lump.fileofs, lump.filelen);
+			}
 		}
 	}
 
@@ -113,17 +166,21 @@ void BSPParser::parse_textures(const uint8_t *data, size_t size) {
 
 			uint32_t pixels = miptex.width * miptex.height;
 			uint32_t datasize = pixels + (pixels / 4) + (pixels / 16) + (pixels / 64);
-
-			// Validate pixel data + palette (2-byte count + 256*3 palette) fits within lump
 			size_t pixel_start = (size_t)ofs + miptex.offsets[0];
-			size_t palette_end = pixel_start + datasize + 2 + 256 * 3;
-			if (palette_end > lump_size) continue;
 
-			const uint8_t *pixel_data = tex_base + pixel_start;
-			const uint8_t *palette = tex_base + pixel_start + datasize + 2;
-
+			// The only format difference is where the palette comes from: Quake miptex carries no
+			// palette (indices map into the global Quake palette), while HL appends a 256-colour
+			// palette (2-byte count + 256*3) after the mip data. Resolve it, then decode once.
+			const uint8_t *palette;
+			if (is_quake) {
+				if (pixel_start + datasize > lump_size) continue;
+				palette = QUAKE_PALETTE;
+			} else {
+				if (pixel_start + datasize + 2 + 256 * 3 > lump_size) continue;
+				palette = tex_base + pixel_start + datasize + 2;
+			}
 			bool has_transparency = (miptex.name[0] == '{');
-			decode_palette_pixels(pixel_data, palette, pixels, has_transparency, tex.data);
+			decode_palette_pixels(tex_base + pixel_start, palette, pixels, has_transparency, tex.data);
 			tex.has_data = true;
 		}
 	}
@@ -314,7 +371,9 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 		pface.texture_name = tex.name;
 		pface.texture_width = tex.width > 0 ? tex.width : 1;
 		pface.texture_height = tex.height > 0 ? tex.height : 1;
-		pface.lightmap_offset = face.lightofs;
+		// Quake lightmaps are grayscale; the lighting lump was expanded ×3 to RGB at load, so byte
+		// offsets into it must be tripled to match (−1 stays "no lightmap").
+		pface.lightmap_offset = (is_quake && face.lightofs >= 0) ? face.lightofs * 3 : face.lightofs;
 		memcpy(pface.styles, face.styles, 4);
 		pface.normal[0] = nx; pface.normal[1] = ny; pface.normal[2] = nz;
 		pface.s_axis[0] = ti.vecs[0][0]; pface.s_axis[1] = ti.vecs[0][1]; pface.s_axis[2] = ti.vecs[0][2];

--- a/src/parsers/bsp_parser.h
+++ b/src/parsers/bsp_parser.h
@@ -7,7 +7,10 @@
 
 namespace goldsrc {
 
-inline constexpr int HLBSP_VERSION = 30;
+inline constexpr int HLBSP_VERSION = 30;  // Half-Life / GoldSrc
+inline constexpr int QBSP_VERSION = 29;   // Quake — same lump layout; textures use the global
+                                          // Quake palette (no embedded palette) and lightmaps are
+                                          // grayscale (1 byte/luxel) instead of HL's RGB.
 
 enum BSPLumpType {
 	LUMP_ENTITIES = 0,
@@ -215,6 +218,7 @@ private:
 	void parse_entities(const uint8_t *data, size_t size);
 
 	BSPHeader header;
+	bool is_quake = false;  // version 29: global-palette textures + grayscale lightmaps
 	std::vector<BSPVertex> vertexes;
 	std::vector<BSPPlane> planes;
 	std::vector<BSPEdge> edges;

--- a/tests/ingame/suites/suite_bsp_load.gd
+++ b/tests/ingame/suites/suite_bsp_load.gd
@@ -12,6 +12,7 @@ func run() -> void:
 	_unloaded_node_is_inert()
 	_loads_the_shipped_map()
 	_rejection_paths()
+	_accepts_quake_version()
 	_both_entry_points_agree()
 
 
@@ -56,6 +57,27 @@ func _rejection_paths() -> void:
 
 	# A failed load must not leave half-parsed state behind.
 	check_eq(bsp.get_leaf_count(), 0, "after a failed load the node is still empty")
+
+
+## Quake maps (BSP version 29) share Half-Life's lump layout and geometry structs, so the parser
+## accepts them alongside v30 — this is what lets a Quake-format map (e.g. ww_castlerush) load at
+## all. Guards the version gate; the Quake-specific texture/lightmap decode is exercised end-to-end
+## by loading a real v29 map, not reachable from a synthetic header here.
+func _accepts_quake_version() -> void:
+	var bsp := GoldSrcBSP.new()
+	track(bsp)
+
+	# A header-sized, otherwise-empty buffer is valid enough to reach — and pass — the version gate.
+	var v29 := PackedByteArray()
+	v29.resize(256)
+	v29.encode_u32(0, 29)
+	check_eq(bsp.load_bsp_from_data(v29), OK, "a version-29 (Quake) header is accepted")
+
+	# Neighbouring versions are still rejected, so acceptance is deliberate, not an "any version" hole.
+	var v31 := PackedByteArray()
+	v31.resize(256)
+	v31.encode_u32(0, 31)
+	check_eq(bsp.load_bsp_from_data(v31), ERR_PARSE_ERROR, "an unsupported BSP version is rejected")
 
 
 ## load_bsp is load_bsp_from_data plus a file read, so the two must agree on the same

--- a/tests/test_parsers.cpp
+++ b/tests/test_parsers.cpp
@@ -463,9 +463,12 @@ struct FaceFixture {
     std::vector<BSPNode> nodes;
     std::vector<BSPLeaf> leafs;
     std::vector<TexSpec> textures;
+    int32_t version = HLBSP_VERSION;   // set to QBSP_VERSION to exercise the Quake path
+    std::vector<uint8_t> lighting;     // raw LUMP_LIGHTING bytes (grayscale for a Quake fixture)
 
     std::vector<uint8_t> build() const {
         BSPBuilder b;
+        b.hdr.version = version;
         b.set_lump(LUMP_VERTEXES, vertexes);
         b.set_lump(LUMP_PLANES, planes);
         b.set_lump(LUMP_EDGES, edges);
@@ -475,6 +478,7 @@ struct FaceFixture {
         b.set_lump(LUMP_MODELS, models);
         b.set_lump(LUMP_NODES, nodes);
         b.set_lump(LUMP_LEAFS, leafs);
+        b.set_lump_bytes(LUMP_LIGHTING, lighting);
         b.set_lump_bytes(LUMP_TEXTURES, make_texture_lump(textures));
         return b.finish();
     }
@@ -776,15 +780,27 @@ TEST_SUITE("BSP entity parsing") {
         CHECK(parser.get_data().entities.empty());
     }
 
-    TEST_CASE("wrong BSP version returns false") {
+    TEST_CASE("unsupported BSP version returns false") {
         BinaryBuilder b;
-        b.le32(29); // wrong version
+        b.le32(31); // neither Quake (29) nor Half-Life (30)
         for (int i = 0; i < 15; i++) {
             b.le32(0);
             b.le32(0);
         }
         BSPParser parser;
         CHECK_FALSE(parser.parse(b.data.data(), b.data.size()));
+    }
+
+    TEST_CASE("Quake BSP version (29) is accepted") {
+        // Quake shares Half-Life's lump layout, so a v29 header parses (to an empty map here).
+        BinaryBuilder b;
+        b.le32(29);
+        for (int i = 0; i < 15; i++) {
+            b.le32(0);
+            b.le32(0);
+        }
+        BSPParser parser;
+        CHECK(parser.parse(b.data.data(), b.data.size()));
     }
 
     TEST_CASE("buffer too small to hold header returns false") {
@@ -1871,6 +1887,41 @@ TEST_SUITE("MDLParser") {
 
 TEST_SUITE("BSP face parsing") {
 
+    TEST_CASE("Quake grayscale lighting is expanded to RGB and lightofs tripled") {
+        FaceFixture fx = make_quad_fixture();
+        fx.version = QBSP_VERSION;
+        fx.lighting = {10, 20, 30, 40};  // grayscale luxels, 1 byte each
+        fx.faces[0].lightofs = 1;         // byte offset into the grayscale lump
+
+        BSPParser parser;
+        auto blob = fx.build();
+        REQUIRE(parser.parse(blob.data(), blob.size()));
+        const BSPData &d = parser.get_data();
+
+        // Each grayscale byte becomes an r=g=b triple, so the lump triples in size.
+        REQUIRE(d.lighting.size() == 12);
+        CHECK(d.lighting[0] == 10); CHECK(d.lighting[1] == 10); CHECK(d.lighting[2] == 10);
+        CHECK(d.lighting[3] == 20); CHECK(d.lighting[4] == 20); CHECK(d.lighting[5] == 20);
+        // The face's byte offset is scaled to index the tripled RGB layout.
+        REQUIRE(d.faces.size() == 1);
+        CHECK(d.faces[0].lightmap_offset == 3);  // 1 * 3
+    }
+
+    TEST_CASE("Half-Life RGB lighting is left untouched") {
+        FaceFixture fx = make_quad_fixture();  // version 30 by default
+        fx.lighting = {10, 20, 30, 40, 50, 60};
+        fx.faces[0].lightofs = 3;
+
+        BSPParser parser;
+        auto blob = fx.build();
+        REQUIRE(parser.parse(blob.data(), blob.size()));
+        const BSPData &d = parser.get_data();
+
+        CHECK(d.lighting.size() == 6);            // unchanged
+        REQUIRE(d.faces.size() == 1);
+        CHECK(d.faces[0].lightmap_offset == 3);   // unchanged
+    }
+
     TEST_CASE("parses a quad face's vertices, UVs and normal") {
         auto blob = make_quad_fixture().build();
 
@@ -2254,6 +2305,29 @@ TEST_SUITE("BSP textures and raw lumps") {
         return lump;
     };
 
+    // The Quake (v29) counterpart: same inline pixels, but no trailing palette — v29 indices
+    // resolve against the global Quake palette instead of a per-miptex one.
+    auto embedded_lump_quake = [](const std::string &name, uint32_t w, uint32_t h, uint8_t fill) {
+        std::vector<uint8_t> lump(8, 0);
+        int32_t count = 1;
+        memcpy(lump.data(), &count, 4);
+        int32_t ofs = 8;
+        memcpy(lump.data() + 4, &ofs, 4);
+
+        BSPMipTex mt{};
+        set_fixed(mt.name, sizeof(mt.name), name);
+        mt.width = w;
+        mt.height = h;
+        mt.offsets[0] = sizeof(BSPMipTex);
+        const uint8_t *p = reinterpret_cast<const uint8_t *>(&mt);
+        lump.insert(lump.end(), p, p + sizeof(mt));
+
+        uint32_t pixels = w * h;
+        uint32_t datasize = pixels + pixels / 4 + pixels / 16 + pixels / 64;
+        lump.insert(lump.end(), datasize, fill);
+        return lump;
+    };
+
     TEST_CASE("decodes an embedded miptex through its palette") {
         uint8_t palette[256 * 3] = {};
         palette[5 * 3 + 0] = 11;
@@ -2299,6 +2373,28 @@ TEST_SUITE("BSP textures and raw lumps") {
         REQUIRE(texs.size() == 1);
         REQUIRE(texs[0].data.size() == 8 * 8 * 4);
         CHECK(texs[0].data[3] == 0); // fully transparent, not opaque blue
+    }
+
+    TEST_CASE("Quake embedded miptex decodes through the global Quake palette") {
+        // A v29 miptex carries no palette. Index 5 must resolve to the global Quake palette's
+        // grayscale-ramp entry (75,75,75) — proving the parser used the built-in palette, not
+        // the bytes that would sit where an HL palette otherwise would.
+        BSPBuilder b;
+        b.hdr.version = QBSP_VERSION;
+        b.set_lump_bytes(LUMP_TEXTURES, embedded_lump_quake("qtex", 8, 8, 5));
+        auto blob = b.finish();
+
+        BSPParser parser;
+        REQUIRE(parser.parse(blob.data(), blob.size()));
+        const auto &texs = parser.get_data().textures;
+
+        REQUIRE(texs.size() == 1);
+        CHECK(texs[0].has_data);
+        REQUIRE(texs[0].data.size() == 8 * 8 * 4);
+        CHECK(texs[0].data[0] == 75);
+        CHECK(texs[0].data[1] == 75);
+        CHECK(texs[0].data[2] == 75);
+        CHECK(texs[0].data[3] == 255);
     }
 
     TEST_CASE("a texture with no embedded pixels is marked external") {


### PR DESCRIPTION
## What

Teach the BSP parser to load **Quake (version 29)** maps alongside Half-Life/GoldSrc (version 30).

Quake and GoldSrc BSP share the same 15-lump layout and geometry structs. A v29 map differs in exactly two places:
- **Textures** index the global Quake palette (no per-miptex palette — HL appends a 256-colour one).
- **Lightmaps** are grayscale (1 byte/luxel) rather than RGB.

Both are normalized into the existing v30 internal representation at parse time (decode against the embedded Quake palette; expand grayscale lighting to RGB and scale face `lightofs` ×3), so every downstream consumer — mesh build, lightstyles, PVS, collision — is untouched. `is_quake` gates every branch, so **v30 parsing is byte-for-byte unchanged**.

## Why

Maps shipped in Quake format (e.g. `ww_castlerush`) were rejected outright by the version check, producing an empty scene with no geometry, entities, or spawns. With this change such a map loads fully (verified end-to-end: real geometry, 262 entities including 13 player spawns, a full nav-bake).

## Tests

- New version-gate check in `suite_bsp_load` (v29 accepted, v31 still rejected).
- Full existing suite unaffected — **96 checks pass**, including `ww_ravine`'s exact face/leaf/entity counts (the regression guard for parser changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)