### PR TITLE
README: document BSP29 (Quake) support alongside BSP30

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Godot 4.3+ GDExtension for loading GoldSrc (Half-Life 1) engine assets: BSP ma
 ## Features
 
 ### BSP Maps
-- Full BSP30 format with face-based mesh generation
+- BSP30 (Half-Life / GoldSrc) and BSP29 (Quake) formats with face-based mesh generation — Quake v29 maps have their global-palette textures and grayscale lightmaps normalized to the v30 representation
 - Atlas-packed lightmaps with 64 lightstyle channels and runtime rebaking
 - Embedded and WAD-referenced textures with transparency (`{` prefix alpha-scissor)
 - Animated textures (`+0name` … `+9name` / `+aname` … `+jname` alternates) — frames collected at import and stored as `tex_anim_frames` metadata on each `MeshInstance3D`; driven at 10 FPS by `TextureAnimator` at runtime with no C++ dependency


### PR DESCRIPTION
## Summary

The README's BSP features list said "Full BSP30 format with face-based mesh generation," but the parser already accepts **both** version 30 (Half-Life / GoldSrc) and version 29 (Quake):

- `bsp_parser.h:10-11` — `HLBSP_VERSION = 30`, `QBSP_VERSION = 29`
- `bsp_parser.cpp:61` — rejects anything that isn't one of those two
- `bsp_parser.cpp:66,83,175,376` — `is_quake` path normalizes Quake's global-palette textures and grayscale lightmaps to the v30 representation

This docs-only change updates the features list to reflect the v29 support (added to load Quake maps like ww_castlerush).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiaYzX4snMPSBLrJQbgPf3