### PR TITLE
Carry the GoldSrc clip hulls in the BSP blob

### DIFF
--- a/addons/goldsrc/importer/bsp_importer.gd
+++ b/addons/goldsrc/importer/bsp_importer.gd
@@ -124,11 +124,13 @@ func _import(source_file: String, save_path: String, options: Dictionary,
 
 	_instantiate_entity_models(root, model_directory)
 
-	# Bake stripped PVS data (PLANES/NODES/LEAFS/VISIBILITY/MODELS only) so
-	# VisibilityManager can initialise from the .scn without the original .bsp.
-	var pvs_blob: PackedByteArray = bsp.get_pvs_blob()
-	if not pvs_blob.is_empty():
-		root.set_meta("pvs_data", pvs_blob)
+	# Bake the stripped BSP (PLANES/NODES/CLIPNODES/LEAFS/VISIBILITY/MODELS) so
+	# VisibilityManager (PVS) and hull collision can both initialise from the .scn
+	# without the original .bsp. Collision bodies carry only a "bsp_model" index
+	# and walk up the tree to find this.
+	var bsp_blob: PackedByteArray = bsp.get_bsp_blob()
+	if not bsp_blob.is_empty():
+		root.set_meta("bsp_data", bsp_blob)
 
 	_set_owner_recursive(root, root)
 

--- a/addons/goldsrc/importer/bsp_importer.gd
+++ b/addons/goldsrc/importer/bsp_importer.gd
@@ -127,8 +127,10 @@ func _import(source_file: String, save_path: String, options: Dictionary,
 	# Bake the stripped BSP (PLANES/NODES/CLIPNODES/LEAFS/VISIBILITY/MODELS) so
 	# VisibilityManager (PVS) and hull collision can both initialise from the .scn
 	# without the original .bsp. Collision bodies carry only a "bsp_model" index
-	# and walk up the tree to find this.
-	var bsp_blob: PackedByteArray = bsp.get_bsp_blob()
+	# and walk up the tree to find this. build_mesh() already parked it on the BSP
+	# node, so read it back rather than rebuilding the whole payload —
+	# PackedByteArray is copy-on-write, so this is a refcount.
+	var bsp_blob: PackedByteArray = bsp.get_meta("bsp_data", PackedByteArray())
 	if not bsp_blob.is_empty():
 		root.set_meta("bsp_data", bsp_blob)
 

--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -481,6 +481,7 @@ GoldSrcBSP::GoldSrcBSP() {
 void GoldSrcBSP::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_bsp", "path"), &GoldSrcBSP::load_bsp);
 	ClassDB::bind_method(D_METHOD("load_bsp_from_data", "data"), &GoldSrcBSP::load_bsp_from_data);
+	ClassDB::bind_method(D_METHOD("get_bsp_blob"), &GoldSrcBSP::get_bsp_blob);
 	ClassDB::bind_method(D_METHOD("get_pvs_blob"), &GoldSrcBSP::get_pvs_blob);
 	ClassDB::bind_method(D_METHOD("set_wad", "wad"), &GoldSrcBSP::set_wad);
 	ClassDB::bind_method(D_METHOD("add_wad", "wad"), &GoldSrcBSP::add_wad);
@@ -542,7 +543,7 @@ Error GoldSrcBSP::load_bsp_from_data(const PackedByteArray &data) {
 	return OK;
 }
 
-PackedByteArray GoldSrcBSP::get_pvs_blob() const {
+PackedByteArray GoldSrcBSP::get_bsp_blob() const {
 	if (!parser) return PackedByteArray();
 	const auto &d = parser->get_data();
 	if (d.nodes.empty() || d.leafs.empty()) return PackedByteArray();
@@ -550,10 +551,11 @@ PackedByteArray GoldSrcBSP::get_pvs_blob() const {
 	size_t planes_sz = d.planes.size()     * sizeof(goldsrc::BSPPlane);
 	size_t vis_sz    = d.visibility.size();
 	size_t nodes_sz  = d.nodes.size()      * sizeof(goldsrc::BSPNode);
+	size_t clips_sz  = d.clipnodes.size()  * sizeof(goldsrc::BSPClipNode);
 	size_t leafs_sz  = d.leafs.size()      * sizeof(goldsrc::BSPLeaf);
 	size_t models_sz = d.models.size()     * sizeof(goldsrc::BSPModel);
 	size_t hdr_sz    = sizeof(goldsrc::BSPHeader);
-	size_t total     = hdr_sz + planes_sz + vis_sz + nodes_sz + leafs_sz + models_sz;
+	size_t total     = hdr_sz + planes_sz + vis_sz + nodes_sz + clips_sz + leafs_sz + models_sz;
 
 	PackedByteArray out;
 	out.resize((int64_t)total);
@@ -575,6 +577,7 @@ PackedByteArray GoldSrcBSP::get_pvs_blob() const {
 	write_lump(goldsrc::LUMP_PLANES,     d.planes.data(),     planes_sz);
 	write_lump(goldsrc::LUMP_VISIBILITY, d.visibility.data(), vis_sz);
 	write_lump(goldsrc::LUMP_NODES,      d.nodes.data(),      nodes_sz);
+	write_lump(goldsrc::LUMP_CLIPNODES,  d.clipnodes.data(),  clips_sz);
 	write_lump(goldsrc::LUMP_LEAFS,      d.leafs.data(),      leafs_sz);
 	write_lump(goldsrc::LUMP_MODELS,     d.models.data(),     models_sz);
 
@@ -961,6 +964,12 @@ void GoldSrcBSP::build_mesh() {
 	if (!parser) return;
 	if (mesh_built) return;
 	mesh_built = true;
+
+	// The stripped BSP rides on the tree root, once, for both the PVS reader and
+	// the hull trace. Bodies carry only a model index (see mark_bsp_carrier); a
+	// consumer walks up from a body to find this. Set before the model loop so
+	// nothing has to remember to do it afterwards.
+	set_meta("bsp_data", get_bsp_blob());
 
 	const auto &bsp_data = parser->get_data();
 	uint64_t t0 = Time::get_singleton()->get_ticks_msec();
@@ -1691,6 +1700,9 @@ void GoldSrcBSP::build_mesh() {
 			// Sky collision body — shapes were added directly from rendering ArrayMesh
 			// objects above; no separate face iteration needed.
 			if (sky_body && sky_body->get_child_count() > 0) {
+				// Sky is passable in hull 0 (that's why projectiles fly through it),
+				// so this body's hull view has to block on CONTENTS_SKY instead.
+				mark_bsp_carrier(sky_body, m, 1 << (-goldsrc::CONTENTS_SKY));
 				model_node->add_child(sky_body);
 				UtilityFunctions::print("[GoldSrc] Sky collision: ",
 					(int64_t)sky_body->get_child_count(), " shape(s) (reused from rendering mesh)");
@@ -1717,6 +1729,7 @@ void GoldSrcBSP::build_mesh() {
 			// Brush entity collision: convex shapes from BSP leaf decomposition.
 			// To revert to triangle-soup collision: change to build_brush_concave.
 			build_brush_convex(body_node, m);
+			if (body_node->get_child_count() > 0) mark_bsp_carrier(body_node, m);
 			// Volume Area3D shares the same shape resources for containment detection.
 			if (body_node->get_child_count() > 0) {
 				Area3D *vol = memnew(Area3D);
@@ -1808,6 +1821,21 @@ void GoldSrcBSP::build_mesh() {
 	}
 }
 
+// Tag a collision body with the BSP model its shapes stand for, so a physics
+// engine that can trace the real hulls (hop's HopBspTraceable) knows which tree
+// to descend and swaps the shapes out for it. Additive: the shapes are still
+// there, and an engine that ignores the metadata — default Godot physics —
+// collides against exactly what it always did.
+//
+// The hull blob itself is NOT copied per body (a big map's is megabytes, and
+// there are hundreds of brush entities); it rides once on the scene root under
+// "bsp_data", and the consumer walks up to find it.
+void GoldSrcBSP::mark_bsp_carrier(Node3D *body, int model_index, int blocking_contents) {
+	body->set_meta("bsp_model", model_index);
+	body->set_meta("bsp_scale", scale_factor);
+	if (blocking_contents != 0) body->set_meta("bsp_blocking", blocking_contents);
+}
+
 void GoldSrcBSP::build_hull_collision(Node3D *parent, int model_index,
 	int hull_index, const String &body_name, uint32_t collision_layer) {
 	const auto &bsp_data = parser->get_data();
@@ -1845,6 +1873,7 @@ void GoldSrcBSP::build_hull_collision(Node3D *parent, int model_index,
 	StaticBody3D *body = memnew(StaticBody3D);
 	body->set_name(body_name);
 	body->set_collision_layer(collision_layer);
+	mark_bsp_carrier(body, model_index);
 
 	Ref<ConcavePolygonShape3D> shape;
 	shape.instantiate();

--- a/src/nodes/goldsrc_bsp.h
+++ b/src/nodes/goldsrc_bsp.h
@@ -28,10 +28,14 @@ public:
 	godot::Error load_bsp(const godot::String &path);
 	godot::Error load_bsp_from_data(const godot::PackedByteArray &data);
 
-	// Returns a stripped BSP30 blob containing only the lumps needed for PVS
-	// queries (PLANES, VISIBILITY, NODES, LEAFS, MODELS). Suitable for storing
-	// as scene metadata so VisibilityManager can run without the original .bsp.
-	godot::PackedByteArray get_pvs_blob() const;
+	// Returns a stripped BSP30 blob — a real BSP file header and lump directory
+	// carrying only PLANES, VISIBILITY, NODES, CLIPNODES, LEAFS and MODELS, with
+	// everything else zeroed. Serves both PVS queries (VisibilityManager) and hull
+	// collision (hop's HopBspTraceable) so one piece of scene metadata covers both
+	// and neither needs the original .bsp at runtime.
+	godot::PackedByteArray get_bsp_blob() const;
+	// Deprecated alias — the blob has carried CLIPNODES since hull collision landed.
+	godot::PackedByteArray get_pvs_blob() const { return get_bsp_blob(); }
 
 	void set_wad(const godot::Ref<GoldSrcWAD> &wad);
 	void add_wad(const godot::Ref<GoldSrcWAD> &wad);
@@ -74,6 +78,10 @@ public:
 private:
 	godot::Ref<godot::ImageTexture> find_texture(const std::string &name) const;
 	godot::Vector3 goldsrc_to_godot(float x, float y, float z) const;
+	// Tags a collision body with the BSP model + scale a hull-tracing physics
+	// engine needs, alongside the shapes it already carries. blocking_contents is
+	// a mask over -CONTENTS_* (0 = the default, CONTENTS_SOLID only).
+	void mark_bsp_carrier(godot::Node3D *body, int model_index, int blocking_contents = 0);
 	void build_hull_collision(godot::Node3D *parent, int model_index,
 		int hull_index, const godot::String &body_name,
 		uint32_t collision_layer);


### PR DESCRIPTION
The `clipnodes` and `headnode[1..3]` lumps have been parsed into `BSPData` all along and never read — every descent uses `headnode[0]`. Those box hulls are what give GoldSrc its exact plane normals and true 18-unit steps, so this ships them to a consumer that can trace them (hop-godot's `HopBspTraceable`).

- `get_pvs_blob` becomes `get_bsp_blob` and writes the CLIPNODES lump alongside the rest. It is still a valid BSP30 file, so the PVS reader is unaffected and one piece of scene metadata now serves both readers. The old name stays as an alias.
- The blob rides once on the tree root under `bsp_data`. It is ~800KB on ww_2fort and a map has hundreds of brush entities, so copying it per body is not an option: each collision body carries only its model index, scale, and (where it differs from `CONTENTS_SOLID`) the contents mask it should block on. A consumer walks up from a body to find the blob.

Purely additive — the concave/convex shapes are untouched, so an engine that ignores the metadata collides against exactly what it always did.

## The sky mask is measured, not assumed

Across ww_2fort / golem / monoliths / chasm the clip hulls contain only SOLID and EMPTY, and every sampled `CONTENTS_SKY` leaf centre reads SOLID in hull 1. So sky blocks players there while staying passable in hull 0 — which is exactly the existing layer-1/layer-9 split, for free.

| map | hull 0 leaf contents | hulls 1–3 clipnode contents |
|---|---|---|
| ww_2fort | SKY:8, SOLID:1, EMPTY:3479 | SOLID:7054, EMPTY:10826 |
| ww_golem | SKY:157, WATER:10, … | SOLID:2418, EMPTY:3783 |
| ww_monoliths | SKY:257, WATER:17, … | SOLID:5406, EMPTY:6401 |
| ww_chasm | SKY:658, WATER:125, … | SOLID:5952, EMPTY:10518 |

Pairs with hop-godot#bsp-hull-traceable. Requires a map cache reconvert (WizardWars `CACHE_VERSION` 26).