### PR TITLE
Composite lightmaps in gamma space, not the renderer's native space

### DIFF
--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -165,6 +165,19 @@ uniform sampler2D lm_layer2 : filter_linear;
 uniform sampler2D lm_layer3 : filter_linear;
 uniform sampler2D lightstyle_tex : filter_nearest;
 uniform float overbright = 2.0;
+// GoldSrc composited texture x lightmap on 8-bit gamma values. The RD renderers
+// (forward+/mobile) shade in linear space and encode on output, gl_compatibility
+// shades in sRGB and does not, so the same expression lands in a different space
+// on each. Do the multiply in gamma space either way and convert once at the end.
+uniform bool linear_output = false;
+
+vec3 gs_to_srgb(vec3 c) {
+	return mix(c * 12.92, 1.055 * pow(max(c, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055, step(0.0031308, c));
+}
+
+vec3 gs_to_linear(vec3 c) {
+	return mix(c / 12.92, pow((max(c, vec3(0.0)) + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));
+}
 
 varying vec4 style_coords;
 
@@ -185,8 +198,13 @@ void fragment() {
 	         + texture(lm_layer2, UV2).rgb * b2
 	         + texture(lm_layer3, UV2).rgb * b3;
 
+	// ALBEDO stays in the renderer's native space so real-time lights stay correct;
+	// only the lightmap term needs the gamma-space treatment. min() before the
+	// conversion reproduces GoldSrc's clamp, which clips differently in linear.
+	vec3 base_srgb = linear_output ? gs_to_srgb(albedo.rgb) : albedo.rgb;
+	vec3 lit_srgb = min(base_srgb * lm * overbright, vec3(1.0));
 	ALBEDO = albedo.rgb;
-	EMISSION = albedo.rgb * lm * overbright;
+	EMISSION = linear_output ? gs_to_linear(lit_srgb) : lit_srgb;
 	ROUGHNESS = 1.0;
 }
 )";
@@ -203,6 +221,19 @@ uniform sampler2D lm_layer2 : filter_linear;
 uniform sampler2D lm_layer3 : filter_linear;
 uniform sampler2D lightstyle_tex : filter_nearest;
 uniform float overbright = 2.0;
+// GoldSrc composited texture x lightmap on 8-bit gamma values. The RD renderers
+// (forward+/mobile) shade in linear space and encode on output, gl_compatibility
+// shades in sRGB and does not, so the same expression lands in a different space
+// on each. Do the multiply in gamma space either way and convert once at the end.
+uniform bool linear_output = false;
+
+vec3 gs_to_srgb(vec3 c) {
+	return mix(c * 12.92, 1.055 * pow(max(c, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055, step(0.0031308, c));
+}
+
+vec3 gs_to_linear(vec3 c) {
+	return mix(c / 12.92, pow((max(c, vec3(0.0)) + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));
+}
 uniform float alpha_scissor_threshold : hint_range(0, 1) = 0.5;
 
 varying vec4 style_coords;
@@ -224,8 +255,13 @@ void fragment() {
 	         + texture(lm_layer2, UV2).rgb * b2
 	         + texture(lm_layer3, UV2).rgb * b3;
 
+	// ALBEDO stays in the renderer's native space so real-time lights stay correct;
+	// only the lightmap term needs the gamma-space treatment. min() before the
+	// conversion reproduces GoldSrc's clamp, which clips differently in linear.
+	vec3 base_srgb = linear_output ? gs_to_srgb(albedo.rgb) : albedo.rgb;
+	vec3 lit_srgb = min(base_srgb * lm * overbright, vec3(1.0));
 	ALBEDO = albedo.rgb;
-	EMISSION = albedo.rgb * lm * overbright;
+	EMISSION = linear_output ? gs_to_linear(lit_srgb) : lit_srgb;
 	ROUGHNESS = 1.0;
 	ALPHA = albedo.a;
 	ALPHA_SCISSOR_THRESHOLD = alpha_scissor_threshold;


### PR DESCRIPTION
The lightstyle shaders multiply a `source_color` albedo by raw lightmap values. That hint makes the RD renderers (forward+/mobile) hand back a **linearised** albedo while the lightmaps stay raw, so the multiply happens in linear space and the frame is sRGB-encoded on output. `gl_compatibility` shades in sRGB and does no conversion at all, so the identical expression lands in a different space on each renderer.

GoldSrc composited texture × lightmap on 8-bit gamma values, which is what the compatibility path happens to reproduce — and what every map was authored and lit against.

## Symptom

Measured on ww_hiddenforest, same seeded spawn, in-engine screenshots of both renderers. Shadowed surfaces lift ~35% under the RD path while highlights are untouched:

```
ground   21.7 -> 29.8 mean luminance  (+36.9%)
wall     19.5 -> 26.3                 (+34.7%)
```

`0` stays `0`, `128` stays `128`, `255` stays `255` — the signature of a mismatched-space multiply rather than a gamma or tonemap error.

## Diagnosis

A constant-`EMISSION` probe settles which space each renderer is in. Rendering `vec3(0.5, 0.25, 0.75)`:

```
gl_compatibility  (122,  61, 184)   = the value as-is
Metal (mobile)    (180, 131, 216)   = the sRGB encoding of it
```

## Fix

Both variants now do the multiply in gamma space and convert once at the end, selected by a `linear_output` uniform the game sets per renderer at map load (runtime, not conversion time — the cached `.scn` outlives any one renderer choice).

`ALBEDO` deliberately stays in the renderer's native space so real-time lights keep working, and the `min()` before conversion reproduces GoldSrc's clamp, which clips differently if done in linear.

## Rejected alternatives, both measured

- **Tagging the lightmaps `source_color` too**: max 7.3/255 error, because sRGB is not a pure power law and its linear toe breaks `enc(dec(a)*dec(l)) == a*l`. The error concentrates in the darks, which is where these maps live.
- **Retuning `overbright` to a linear constant**: no single value works. It is 4.67 in the unclamped region but the clamp at white drags it to 1.91–4.21 as surfaces approach saturation.

## Result

GL vs Metal gap on world surfaces goes from +35% to +10–20%, with `gl_compatibility` itself unchanged (0.0% / −0.1%). The residual is real-time light contribution — these shaders are not `unshaded`, so Godot's own lighting path composites in the renderer's native space. Left alone deliberately: linear light accumulation is the more defensible behaviour there.

Needs the game-side companion (wizardwars `a4cdf32`), which sets `linear_output` and bumps `CACHE_VERSION` — the world shader source is baked into cached scenes, so without the bump they keep the old code and the uniform is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R2B7Xd2x9k5rrRdXN782D