### PR TITLE
Merge an MDL's meshes into one MeshInstance3D per bodypart

### DIFF
--- a/addons/goldsrc/importer/mdl_importer.gd
+++ b/addons/goldsrc/importer/mdl_importer.gd
@@ -30,6 +30,12 @@ func _get_preset_name(preset_index: int) -> String:
 	return "Default"
 
 
+## Bump when the built scene's shape changes, so every .mdl reimports rather than loading a
+## cached scene from the old importer. 1: meshes merged into one MeshInstance3D per bodypart.
+func _get_format_version() -> int:
+	return 1
+
+
 func _get_priority() -> float:
 	return 1.0
 

--- a/src/nodes/goldsrc_mdl.cpp
+++ b/src/nodes/goldsrc_mdl.cpp
@@ -120,15 +120,15 @@ void GoldSrcMDL::set_skin(int family) {
 	const auto &mdl = parser->get_data();
 	if (family < 0 || family >= mdl.num_skin_families) return;
 
-	for (auto &[mesh_inst, skin_ref] : mesh_skin_refs) {
-		if (!mesh_inst) continue;
-		int tex_idx = skin_ref;
-		int table_idx = family * mdl.num_skin_ref + skin_ref;
+	for (const auto &ref : mesh_skin_refs) {
+		if (!ref.mesh_inst) continue;
+		int tex_idx = ref.skin_ref;
+		int table_idx = family * mdl.num_skin_ref + ref.skin_ref;
 		if (table_idx >= 0 && table_idx < (int)mdl.skin_table.size()) {
 			tex_idx = mdl.skin_table[table_idx];
 		}
 		if (tex_idx >= 0 && tex_idx < (int)stored_materials.size()) {
-			mesh_inst->set_surface_override_material(0, stored_materials[tex_idx]);
+			ref.mesh_inst->set_surface_override_material(ref.surface, stored_materials[tex_idx]);
 		}
 	}
 }
@@ -414,12 +414,18 @@ void GoldSrcMDL::build_meshes() {
 	}
 	stored_materials = materials;
 
-	// Build mesh for each bodypart (first model only for now)
+	// One MeshInstance3D per bodypart (first model only for now), carrying each of the
+	// submodel's meshes as its own surface. A GoldSrc mesh is a texture batch, which is what a
+	// Godot surface is; the bodypart is the swappable unit, which is what a node is for.
 	for (int bp = 0; bp < (int)mdl.bodyparts.size(); bp++) {
 		const auto &bodypart = mdl.bodyparts[bp];
 		if (bodypart.models.empty()) continue;
 
 		const auto &submodel = bodypart.models[0]; // Default model
+
+		Ref<ArrayMesh> arr_mesh;
+		arr_mesh.instantiate();
+		vector<pair<int, int>> surface_skin_refs; // surface -> skin_ref, until the instance exists
 
 		for (int mi = 0; mi < (int)submodel.meshes.size(); mi++) {
 			const auto &mesh = submodel.meshes[mi];
@@ -495,9 +501,6 @@ void GoldSrcMDL::build_meshes() {
 				indices.push_back(t);
 			}
 
-			Ref<ArrayMesh> arr_mesh;
-			arr_mesh.instantiate();
-
 			Array arrays;
 			arrays.resize(ArrayMesh::ARRAY_MAX);
 			arrays[ArrayMesh::ARRAY_VERTEX] = vertices;
@@ -510,6 +513,7 @@ void GoldSrcMDL::build_meshes() {
 				arrays[ArrayMesh::ARRAY_WEIGHTS] = bone_weights;
 			}
 
+			int surface = arr_mesh->get_surface_count();
 			arr_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
 
 			int skin_ref = mesh.skin_ref;
@@ -518,22 +522,28 @@ void GoldSrcMDL::build_meshes() {
 				tex_idx = mdl.skin_table[tex_idx];
 			}
 			if (tex_idx >= 0 && tex_idx < (int)materials.size()) {
-				arr_mesh->surface_set_material(0, materials[tex_idx]);
+				arr_mesh->surface_set_material(surface, materials[tex_idx]);
 			}
+			surface_skin_refs.push_back({surface, skin_ref});
+		}
 
-			MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
-			String mesh_name = String(bodypart.name.c_str()) + "_mesh" + String::num_int64(mi);
-			mesh_instance->set_name(mesh_name);
-			mesh_instance->set_mesh(arr_mesh);
+		if (arr_mesh->get_surface_count() == 0) continue;
 
-			if (skeleton) {
-				skeleton->add_child(mesh_instance);
-				mesh_instance->set_skeleton_path(NodePath(".."));
-			} else {
-				add_child(mesh_instance);
-			}
+		MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
+		String mesh_name = String(bodypart.name.c_str()).validate_node_name();
+		mesh_instance->set_name(mesh_name.is_empty()
+			? "bodypart" + String::num_int64(bp) : mesh_name);
+		mesh_instance->set_mesh(arr_mesh);
 
-			mesh_skin_refs.push_back({mesh_instance, skin_ref});
+		if (skeleton) {
+			skeleton->add_child(mesh_instance);
+			mesh_instance->set_skeleton_path(NodePath(".."));
+		} else {
+			add_child(mesh_instance);
+		}
+
+		for (const auto &[surface, skin_ref] : surface_skin_refs) {
+			mesh_skin_refs.push_back({mesh_instance, surface, skin_ref});
 		}
 	}
 }

--- a/src/nodes/goldsrc_mdl.h
+++ b/src/nodes/goldsrc_mdl.h
@@ -52,7 +52,14 @@ private:
 	godot::Skeleton3D *skeleton = nullptr;
 	std::vector<godot::Transform3D> rest_bone_world; // cached rest-pose world transforms
 	std::vector<godot::Ref<godot::StandardMaterial3D>> stored_materials;
-	std::vector<std::pair<godot::MeshInstance3D*, int>> mesh_skin_refs; // mesh instance + skin_ref
+	// One entry per surface: the instance holding it, which surface it is, and the GoldSrc
+	// mesh's skin_ref — what set_skin() looks a family's texture up by.
+	struct MeshSkinRef {
+		godot::MeshInstance3D *mesh_inst;
+		int surface;
+		int skin_ref;
+	};
+	std::vector<MeshSkinRef> mesh_skin_refs;
 	float scale_factor = 0.025f;
 	bool model_built = false;
 };


### PR DESCRIPTION
`build_meshes` made a node per GoldSrc mesh, so `raisedead.mdl` arrived as 11 sibling `MeshInstance3D`s belonging to one bodypart. A GoldSrc mesh is a texture batch — that is what a Godot *surface* is; the bodypart is the swappable unit, which is what a node is for.

Now one instance per bodypart, each mesh added as its own surface with its own material. `mesh_skin_refs` carries the surface index next to the `skin_ref` so `set_skin()` overrides the right surface; verified against `fire.mdl`, whose five skin families swap surface 0 and leave surface 1 alone.

Structure, not speed: 30 animating skeletons measured 16.0 fps before and after. Under `gl_compatibility` a skinned model's per-frame cost tracks its *surface* count (~0.2 ms each), which this does not change — only atlasing the textures into a single material would, and that is deliberately out of scope.

`_get_format_version()` forces a reimport rather than loading scenes built by the old code. It writes `importer_version` into the `.import` files, which were not carrying one before, so this first bump needs `.godot/imported/*.mdl-*` cleared by hand; later bumps fire on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLL9hX1K6HYuN3XaDczcB