### PR TITLE
Weld an MDL's triangle corners back into shared vertices

### DIFF
--- a/addons/goldsrc/importer/mdl_importer.gd
+++ b/addons/goldsrc/importer/mdl_importer.gd
@@ -30,10 +30,15 @@ func _get_preset_name(preset_index: int) -> String:
 	return "Default"
 
 
-## Bump when the built scene's shape changes, so every .mdl reimports rather than loading a
-## cached scene from the old importer. 1: meshes merged into one MeshInstance3D per bodypart.
+## What shape of scene this importer builds. 1: meshes merged into one MeshInstance3D per
+## bodypart. 2: triangle corners welded back into shared vertices.
+##
+## Godot records it in each .import file but does not act on a bump — neither --import nor an
+## editor session reimports on its own (checked on 4.7). Changing the built scene means clearing
+## .godot/imported/*.mdl-* by hand; the number is here so it is visible which build a cache came
+## from.
 func _get_format_version() -> int:
-	return 1
+	return 2
 
 
 func _get_priority() -> float:

--- a/src/nodes/goldsrc_mdl.cpp
+++ b/src/nodes/goldsrc_mdl.cpp
@@ -18,6 +18,8 @@
 
 #include <cmath>
 #include <cstring>
+#include <map>
+#include <tuple>
 
 using namespace godot;
 using namespace std;
@@ -438,14 +440,19 @@ void GoldSrcMDL::build_meshes() {
 			PackedFloat32Array bone_weights;
 			PackedInt32Array indices;
 
-			for (int t = 0; t < (int)mesh.triangle_verts.size(); t++) {
-				const auto &tv = mesh.triangle_verts[t];
+			// A GoldSrc mesh indexes the submodel's shared vertex pool, and the strip/fan
+			// expansion hands us one entry per triangle corner — so writing a vertex per
+			// corner stores the model several times over (raisedead: 2343 for a 449-vertex
+			// model). Corners agreeing on position, normal and UV are one vertex; the rest
+			// split, as they must at a UV seam or a smoothing break.
+			map<tuple<int, int, float, float>, int> welded;
 
+			auto weld_corner = [&](const goldsrc::ParsedTriVertex &tv) -> int {
 				int vi = tv.vertex_index;
 				int ni = tv.normal_index;
-
-				if (vi * 3 + 2 >= (int)submodel.vertices.size()) continue;
-				if (ni * 3 + 2 >= (int)submodel.normals.size()) continue;
+				auto key = make_tuple(vi, ni, tv.s, tv.t);
+				auto found = welded.find(key);
+				if (found != welded.end()) return found->second;
 
 				float vx = submodel.vertices[vi * 3 + 0];
 				float vy = submodel.vertices[vi * 3 + 1];
@@ -498,7 +505,24 @@ void GoldSrcMDL::build_meshes() {
 				bone_weights.push_back(0.0f);
 				bone_weights.push_back(0.0f);
 
-				indices.push_back(t);
+				int index = (int)vertices.size() - 1;
+				welded[key] = index;
+				return index;
+			};
+
+			// Whole triangles: a corner pointing outside the pool takes its triangle with it,
+			// rather than leaving the two beside it to join the next one.
+			for (int t = 0; t + 2 < (int)mesh.triangle_verts.size(); t += 3) {
+				bool corners_valid = true;
+				for (int c = 0; c < 3 && corners_valid; c++) {
+					const auto &tv = mesh.triangle_verts[t + c];
+					corners_valid = tv.vertex_index * 3 + 2 < (int)submodel.vertices.size()
+						&& tv.normal_index * 3 + 2 < (int)submodel.normals.size();
+				}
+				if (!corners_valid) continue;
+				for (int c = 0; c < 3; c++) {
+					indices.push_back(weld_corner(mesh.triangle_verts[t + c]));
+				}
 			}
 
 			Array arrays;


### PR DESCRIPTION
A GoldSrc mesh indexes its submodel's shared vertex pool, and the strip/fan expansion hands the importer one entry per triangle corner. It wrote a vertex per corner with indices `0,1,2,…`, so every model was stored several times over — `raisedead.mdl` as 2343 vertices for a 449-vertex pool.

Corners agreeing on position, normal and UV are now one vertex; the rest still split, as they must at a UV seam or a smoothing break. Triangle counts are unchanged.

| model | before | after |
|---|---|---|
| raisedead | 2343 | 498 |
| fire (player) | 2523 | 577 |
| dragon | 2895 | 753 |
| wombat | 540 | 124 |

**No frame-time change on any renderer** — 100 animating skeletons: mobile 4.91→4.93 ms, forward_plus 5.73→5.67 ms, gl_compatibility 62.9→63.0 ms. Nothing is vertex-bound at that scale on this machine. What changes is what gets stored (raisedead's imported scene lost 81 KB) and how much a GPU has to skin, which is a Quest question and untested here.

Also closes a corruption path: a corner pointing outside the pool used to be skipped while the running index kept counting, leaving every index after it addressing the wrong vertex. Triangles are validated whole and dropped whole.

Format version → 2, with its comment corrected: Godot records `importer_version` but does not reimport on a bump (checked on 4.7, both `--import` and an editor session). A changed importer still needs `.godot/imported/*.mdl-*` cleared by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLL9hX1K6HYuN3XaDczcB