### PR TITLE
World and skin textures filter anisotropically off a mip chain

### DIFF
--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -158,7 +158,7 @@ static const char *LIGHTSTYLE_SHADER_CODE = R"(
 shader_type spatial;
 render_mode ambient_light_disabled, specular_disabled;
 
-uniform sampler2D albedo_texture : source_color;
+uniform sampler2D albedo_texture : source_color, filter_linear_mipmap_anisotropic;
 uniform sampler2D lm_layer0 : filter_linear;
 uniform sampler2D lm_layer1 : filter_linear;
 uniform sampler2D lm_layer2 : filter_linear;
@@ -214,7 +214,7 @@ static const char *LIGHTSTYLE_SHADER_ALPHA_CODE = R"(
 shader_type spatial;
 render_mode ambient_light_disabled, specular_disabled;
 
-uniform sampler2D albedo_texture : source_color;
+uniform sampler2D albedo_texture : source_color, filter_linear_mipmap_anisotropic;
 uniform sampler2D lm_layer0 : filter_linear;
 uniform sampler2D lm_layer1 : filter_linear;
 uniform sampler2D lm_layer2 : filter_linear;
@@ -303,7 +303,7 @@ static const char *WATER_SHADER_CODE = R"(
 shader_type spatial;
 render_mode unshaded, shadows_disabled, ambient_light_disabled, cull_disabled, depth_draw_never;
 
-uniform sampler2D albedo_texture : source_color;
+uniform sampler2D albedo_texture : source_color, filter_linear_mipmap_anisotropic;
 uniform float wave_amplitude : hint_range(0.0, 0.1) = 0.025;
 uniform float wave_frequency : hint_range(1.0, 20.0) = 8.0;
 uniform float wave_speed : hint_range(0.1, 5.0) = 1.6;

--- a/src/nodes/goldsrc_mdl.cpp
+++ b/src/nodes/goldsrc_mdl.cpp
@@ -394,6 +394,10 @@ void GoldSrcMDL::build_meshes() {
 
 		Ref<Image> img = Image::create_from_data(tex.width, tex.height,
 			false, Image::FORMAT_RGBA8, pixels);
+		// Skin pixels are always fully opaque (mdl_parser writes alpha 255), so a mip chain
+		// cannot bleed transparent-black in — and without one a player across the map is a
+		// crawling mess of aliased texels.
+		img->generate_mipmaps();
 		Ref<ImageTexture> gtex = ImageTexture::create_from_image(img);
 		godot_textures.push_back(gtex);
 


### PR DESCRIPTION
BSP albedo was sampled with no filter hint, so floors and long walls dissolved into shimmer at grazing angles. Adding `filter_linear_mipmap_anisotropic` to the three world albedo samplers (lightstyle, its alpha-scissor twin, water) costs nothing on any GPU of the last fifteen years — the WAD and embedded-BSP textures already carry mip chains.

MDL skins had no mip chain at all: `Image::create_from_data(..., false, ...)` built a single level, so `mdl_ambient_cube.gdshader`'s `filter_linear_mipmap` had nothing to fall back to and a player across the map crawled with aliasing. Skin pixels are always fully opaque (`mdl_parser.cpp` writes alpha 255), so the generated chain cannot bleed transparent black into the edges.

Consumers must bump their conversion cache versions — both changes bake into the cached `.scn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jLL9hX1K6HYuN3XaDczcB