### PR TITLE
Liquid is what the map says it is, and coincident water brushes stop erasing each other

### DIFF
--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -286,25 +286,23 @@ void fragment() {
 }
 )";
 
-// Which liquid a surface LOOKS like. Gameplay (swim physics, damage) reads the entity's
-// "skin" key instead; this is only motion. Derived from the texture name rather than skin
-// because the name is the signal that always exists and is always right: ww_golem's lava
-// brush is skin -3 (water contents) with a lava texture, and worldspawn liquid carries no
-// entity to have a skin at all. Keying on the name also makes this a pure function of the
-// material cache key, so two liquids can never land in one cache slot.
+// Which liquid a surface is, as the shader's liquid_type. GoldSrc kept this in one place per
+// kind of brush and never in the texture name: a brush entity carries it in its "skin" key
+// (CFuncDoor::KeyValue stores it straight into pev->skin), and a worldspawn surface takes it
+// from the leaf it borders, which the compiler had already resolved from the name at build
+// time. Both are the same CONTENTS_* value, so both come through here.
 //
-// "icy" and not "ice": ww_osaka's rice-paddy texture is !osaka_rice, and a substring test
-// for "ice" freezes it.
-enum LiquidKind { LIQUID_WATER = 0, LIQUID_SLIME = 1, LIQUID_LAVA = 2, LIQUID_ICE = 3 };
+// Reading the name instead would be re-deriving what the compiler already decided, and it gets
+// it wrong: ww_golem's lava-textured brush is deliberately skin -3, plain water that does not
+// burn, and any texture whose name merely contains "lava" or "rice" would be miscalled.
+enum LiquidKind { LIQUID_WATER = 0, LIQUID_SLIME = 1, LIQUID_LAVA = 2 };
 
-static LiquidKind liquid_kind_for_texture(const std::string &tex_name) {
-	std::string n;
-	n.reserve(tex_name.size());
-	for (char c : tex_name) n += (char)tolower((unsigned char)c);
-	if (n.find("lava") != std::string::npos || n.find("magma") != std::string::npos) return LIQUID_LAVA;
-	if (n.find("slime") != std::string::npos) return LIQUID_SLIME;
-	if (n.find("icy") != std::string::npos || n.find("frozen") != std::string::npos) return LIQUID_ICE;
-	return LIQUID_WATER;
+static LiquidKind liquid_kind_for_contents(int contents) {
+	switch (contents) {
+		case goldsrc::CONTENTS_SLIME: return LIQUID_SLIME;
+		case goldsrc::CONTENTS_LAVA: return LIQUID_LAVA;
+		default: return LIQUID_WATER;
+	}
 }
 
 // Water surface shader: turbulent UV warp to simulate GoldSrc liquid surfaces.
@@ -330,16 +328,19 @@ uniform float wave_amplitude : hint_range(0.0, 0.1) = 0.025;
 uniform float wave_frequency : hint_range(1.0, 20.0) = 8.0;
 uniform float wave_speed : hint_range(0.1, 5.0) = 1.6;
 uniform float water_alpha : hint_range(0.0, 1.0) = 0.6;
-// 0 water, 1 slime, 2 lava, 3 ice — see liquid_kind_for_texture. Water is left at 1.0/1.0
-// so every map that already had liquid keeps exactly the surface it had.
-uniform int liquid_type : hint_range(0, 3) = 0;
+// 0 water, 1 slime, 2 lava — the brush's CONTENTS_*, see liquid_kind_for_contents. Water is
+// left at 1.0/1.0 so every map that already had liquid keeps exactly the surface it had.
+//
+// GoldSrc ran one warp for all three; separating them is ours. It stops at what the map cannot
+// say for itself: how still a surface is belongs to WaveHeight, which the mapper sets per brush
+// (ww_matrox has an ice brush at 5 and another at 0), so nothing here may override it.
+uniform int liquid_type : hint_range(0, 2) = 0;
 
 void fragment() {
 	float speed_mul = 1.0;
 	float amp_mul = 1.0;
 	if (liquid_type == 1) { speed_mul = 0.6; amp_mul = 1.2; }        // slime: thicker, slower
 	else if (liquid_type == 2) { speed_mul = 0.25; amp_mul = 1.6; }  // lava: slow, wide roll
-	else if (liquid_type == 3) { speed_mul = 0.06; amp_mul = 0.2; }  // ice: all but still
 
 	vec2 uv = UV;
 	float phase = TIME * wave_speed * speed_mul;
@@ -1237,6 +1238,16 @@ void GoldSrcBSP::build_mesh() {
 		// ww_countryside, ww_ravine2), scrollwater1/2 (ww_osaka, ww_ravine2) — and those maps
 		// rendered their pools as ordinary opaque brushwork with an alpha slapped on top.
 		const bool ent_is_liquid = (classname == "func_water");
+		// A brush entity names its liquid in "skin"; worldspawn liquid has no entity and is
+		// read per face from the leaf it borders (ParsedFace::liquid_contents).
+		int ent_skin = goldsrc::CONTENTS_WATER;
+		if (m > 0) {
+			auto ent_it = model_entities.find(model_key);
+			if (ent_it != model_entities.end()) {
+				auto sk = ent_it->second->properties.find("skin");
+				if (sk != ent_it->second->properties.end()) ent_skin = atoi(sk->second.c_str());
+			}
+		}
 
 		// Create a node for this model. Worldspawn is a plain container; brush
 		// entities are AnimatableBody3D roots so their entity transform is the
@@ -1754,7 +1765,20 @@ void GoldSrcBSP::build_mesh() {
 				Ref<ShaderMaterial> material;
 				material.instantiate();
 				material->set_shader(water_shader);
-				material->set_shader_parameter("liquid_type", (int)liquid_kind_for_texture(tex_name));
+				int liquid_contents = ent_skin;
+				if (m == 0) {
+					// Worldspawn: take the first face in the group that borders a liquid. A
+					// texture group is one surface of one pool, so they agree.
+					liquid_contents = goldsrc::CONTENTS_WATER;
+					for (const auto &fr : face_refs) {
+						if (fr.face->liquid_contents != 0) {
+							liquid_contents = fr.face->liquid_contents;
+							break;
+						}
+					}
+				}
+				material->set_shader_parameter("liquid_type",
+						(int)liquid_kind_for_contents(liquid_contents));
 				if (texture.is_valid()) {
 					material->set_shader_parameter("albedo_texture", texture);
 				}

--- a/src/nodes/goldsrc_bsp.cpp
+++ b/src/nodes/goldsrc_bsp.cpp
@@ -286,8 +286,30 @@ void fragment() {
 }
 )";
 
+// Which liquid a surface LOOKS like. Gameplay (swim physics, damage) reads the entity's
+// "skin" key instead; this is only motion. Derived from the texture name rather than skin
+// because the name is the signal that always exists and is always right: ww_golem's lava
+// brush is skin -3 (water contents) with a lava texture, and worldspawn liquid carries no
+// entity to have a skin at all. Keying on the name also makes this a pure function of the
+// material cache key, so two liquids can never land in one cache slot.
+//
+// "icy" and not "ice": ww_osaka's rice-paddy texture is !osaka_rice, and a substring test
+// for "ice" freezes it.
+enum LiquidKind { LIQUID_WATER = 0, LIQUID_SLIME = 1, LIQUID_LAVA = 2, LIQUID_ICE = 3 };
+
+static LiquidKind liquid_kind_for_texture(const std::string &tex_name) {
+	std::string n;
+	n.reserve(tex_name.size());
+	for (char c : tex_name) n += (char)tolower((unsigned char)c);
+	if (n.find("lava") != std::string::npos || n.find("magma") != std::string::npos) return LIQUID_LAVA;
+	if (n.find("slime") != std::string::npos) return LIQUID_SLIME;
+	if (n.find("icy") != std::string::npos || n.find("frozen") != std::string::npos) return LIQUID_ICE;
+	return LIQUID_WATER;
+}
+
 // Water surface shader: turbulent UV warp to simulate GoldSrc liquid surfaces.
-// Applied to faces whose texture name starts with '!' or '*'.
+// Applied to faces whose texture name starts with '!' or '*', and to every face of a
+// func_water brush whatever its texture is called (see ent_is_liquid in build_mesh).
 // GoldSrc water is translucent and visible from both sides (you see the surface from
 // above and, when submerged, from below), so the material writes ALPHA and disables
 // backface culling. cull_back would hide the inner faces and leave opaque water slabs.
@@ -308,11 +330,22 @@ uniform float wave_amplitude : hint_range(0.0, 0.1) = 0.025;
 uniform float wave_frequency : hint_range(1.0, 20.0) = 8.0;
 uniform float wave_speed : hint_range(0.1, 5.0) = 1.6;
 uniform float water_alpha : hint_range(0.0, 1.0) = 0.6;
+// 0 water, 1 slime, 2 lava, 3 ice — see liquid_kind_for_texture. Water is left at 1.0/1.0
+// so every map that already had liquid keeps exactly the surface it had.
+uniform int liquid_type : hint_range(0, 3) = 0;
 
 void fragment() {
+	float speed_mul = 1.0;
+	float amp_mul = 1.0;
+	if (liquid_type == 1) { speed_mul = 0.6; amp_mul = 1.2; }        // slime: thicker, slower
+	else if (liquid_type == 2) { speed_mul = 0.25; amp_mul = 1.6; }  // lava: slow, wide roll
+	else if (liquid_type == 3) { speed_mul = 0.06; amp_mul = 0.2; }  // ice: all but still
+
 	vec2 uv = UV;
-	uv.x += sin(uv.y * wave_frequency + TIME * wave_speed) * wave_amplitude;
-	uv.y += sin(uv.x * wave_frequency + TIME * wave_speed) * wave_amplitude;
+	float phase = TIME * wave_speed * speed_mul;
+	float amp = wave_amplitude * amp_mul;
+	uv.x += sin(uv.y * wave_frequency + phase) * amp;
+	uv.y += sin(uv.x * wave_frequency + phase) * amp;
 	ALBEDO = texture(albedo_texture, uv).rgb;
 	ALPHA = water_alpha;
 	ROUGHNESS = 1.0;
@@ -1199,6 +1232,12 @@ void GoldSrcBSP::build_mesh() {
 			}
 		}
 
+		// A func_water brush is liquid whatever its texture is called. Half the game's water
+		// is on unprefixed names the '!'/'*' test below cannot see — water4b (ww_2fort,
+		// ww_countryside, ww_ravine2), scrollwater1/2 (ww_osaka, ww_ravine2) — and those maps
+		// rendered their pools as ordinary opaque brushwork with an alpha slapped on top.
+		const bool ent_is_liquid = (classname == "func_water");
+
 		// Create a node for this model. Worldspawn is a plain container; brush
 		// entities are AnimatableBody3D roots so their entity transform is the
 		// physical/rendered brush transform.
@@ -1588,7 +1627,8 @@ void GoldSrcBSP::build_mesh() {
 			PackedInt32Array indices;
 			int vert_offset = 0;
 
-			bool is_water_group = !tex_name.empty() && (tex_name[0] == '!' || tex_name[0] == '*');
+			bool is_water_group = ent_is_liquid
+					|| (!tex_name.empty() && (tex_name[0] == '!' || tex_name[0] == '*'));
 
 			for (size_t fi = 0; fi < face_refs.size(); fi++) {
 				const auto *face = face_refs[fi].face;
@@ -1690,7 +1730,8 @@ void GoldSrcBSP::build_mesh() {
 
 			Ref<ImageTexture> texture = find_texture(tex_name);
 			bool is_sky_surface = goldsrc::is_sky_texture(tex_name);
-			bool is_water = !is_sky_surface && !tex_name.empty() && (tex_name[0] == '!' || tex_name[0] == '*');
+			bool is_water = !is_sky_surface && (ent_is_liquid
+					|| (!tex_name.empty() && (tex_name[0] == '!' || tex_name[0] == '*')));
 			bool is_alpha_scissor = !is_sky_surface && !is_water && !tex_name.empty() && tex_name[0] == '{';
 
 			// Build the material once per (texture, page) and hand the same one to every mesh
@@ -1713,6 +1754,7 @@ void GoldSrcBSP::build_mesh() {
 				Ref<ShaderMaterial> material;
 				material.instantiate();
 				material->set_shader(water_shader);
+				material->set_shader_parameter("liquid_type", (int)liquid_kind_for_texture(tex_name));
 				if (texture.is_valid()) {
 					material->set_shader_parameter("albedo_texture", texture);
 				}

--- a/src/parsers/bsp_parser.cpp
+++ b/src/parsers/bsp_parser.cpp
@@ -266,6 +266,7 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 		// Cull internal water faces. In GoldSrc, water brush entities only show
 		// their top surface — side and bottom faces are hidden behind pool
 		// geometry. For worldspawn water, check both sides against the BSP tree.
+		int face_liquid_contents = 0; // CONTENTS_WATER/SLIME/LAVA for a worldspawn liquid face
 		if (face.planenum >= 0 && (size_t)face.planenum < planes.size()) {
 			const auto &pl = planes[face.planenum];
 			float nx = pl.normal[0], ny = pl.normal[1], nz = pl.normal[2];
@@ -351,7 +352,7 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 				if (nv_center > 0) {
 					cx /= nv_center; cy /= nv_center; cz /= nv_center;
 					int root_node = bsp_data.models[0].headnode[0];
-					bool both_water = true;
+					int side_contents[2] = {0, 0};
 					for (int s = 0; s < 2; s++) {
 						float sign = s == 0 ? 1.0f : -1.0f;
 						float probe[3] = {
@@ -369,13 +370,25 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 							ni = d >= 0 ? nd.children[0] : nd.children[1];
 						}
 						int li = -(ni + 1);
-						if (li < 0 || (size_t)li >= leafs.size() ||
-						    leafs[li].contents != CONTENTS_WATER) {
-							both_water = false;
-							break;
-						}
+						side_contents[s] = (li >= 0 && (size_t)li < leafs.size())
+								? leafs[li].contents : 0;
 					}
-					if (both_water) { water_faces_culled++; continue; }
+
+					// Which liquid this surface belongs to. The compiler resolved the texture
+					// name into leaf contents when it built the map and GoldSrc read the leaf,
+					// so this is its answer rather than a second guess at the name. Lava and
+					// slime win over water: a face between two liquids is the more specific one.
+					for (int s = 0; s < 2; s++) {
+						int c = side_contents[s];
+						if (c == CONTENTS_LAVA || c == CONTENTS_SLIME ||
+						    (c == CONTENTS_WATER && face_liquid_contents == 0))
+							face_liquid_contents = c;
+					}
+
+					if (side_contents[0] == CONTENTS_WATER && side_contents[1] == CONTENTS_WATER) {
+						water_faces_culled++;
+						continue;
+					}
 				}
 			}
 		}
@@ -393,6 +406,7 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 
 		ParsedFace pface;
 		pface.model_index = face_to_model[f];
+		pface.liquid_contents = face_liquid_contents;
 		pface.texture_name = tex.name;
 		pface.texture_width = tex.width > 0 ? tex.width : 1;
 		pface.texture_height = tex.height > 0 ? tex.height : 1;

--- a/src/parsers/bsp_parser.cpp
+++ b/src/parsers/bsp_parser.cpp
@@ -215,6 +215,37 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 			water_model_set.insert(mi);
 	}
 
+	// Is `p` inside `model_index`'s solid? Walks hull 0 (exact brush geometry) rather than
+	// hull 1 (clipnodes), which is expanded by the player bbox and would false-positive on
+	// nearby but non-overlapping brushes — a waterfall beside a pool, say.
+	auto point_in_model = [&](int model_index, const float p[3]) -> bool {
+		int ni = raw_models[model_index].headnode[0];
+		while (ni >= 0 && (size_t)ni < nodes.size()) {
+			const auto &nd = nodes[ni];
+			if (nd.planenum < 0 || (size_t)nd.planenum >= planes.size()) break;
+			const auto &np = planes[nd.planenum];
+			float d = np.normal[0] * p[0] + np.normal[1] * p[1] + np.normal[2] * p[2] - np.dist;
+			ni = d >= 0 ? nd.children[0] : nd.children[1];
+		}
+		int li = -(ni + 1); // negative ni = leaf index: -(ni+1)
+		return li >= 0 && (size_t)li < leafs.size() && leafs[li].contents == CONTENTS_SOLID;
+	};
+
+	// A water brush something can trigger is a water brush that can MOVE: func_water is
+	// CFuncDoor in the HL SDK, which is how ww_volcano's *75 ("volc", speed 25, lip 160) is a
+	// rising lava flood. This cull is baked into the converted scene, so a face dropped as
+	// "buried" stays dropped once the brush has moved off it and leaves a hole. So cull only
+	// against geometry that cannot move — a movable water brush is neither culled itself nor
+	// used as a reason to cull anything else.
+	set<int> movable_water_models;
+	for (const auto &ent : bsp_data.entities) {
+		auto mit = ent.properties.find("model");
+		if (mit == ent.properties.end() || mit->second.empty() || mit->second[0] != '*') continue;
+		if (ent.properties.find("targetname") == ent.properties.end()) continue;
+		int mi = atoi(mit->second.c_str() + 1);
+		if (water_model_set.count(mi)) movable_water_models.insert(mi);
+	}
+
 	int water_faces_culled = 0;
 	for (size_t f = 0; f < raw_faces.size(); f++) {
 		const BSPFace &face = raw_faces[f];
@@ -243,7 +274,8 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 			// For water brush entity faces: cull if the outside of this face
 			// is inside another water model's BSP volume (internal seam between
 			// adjacent water volumes). Keep exposed faces (e.g. waterfalls).
-			if (water_model_set.count(face_to_model[f])) {
+			if (water_model_set.count(face_to_model[f]) &&
+			    !movable_water_models.count(face_to_model[f])) {
 				// Compute face center
 				float wcx = 0, wcy = 0, wcz = 0;
 				int wnv = 0;
@@ -262,14 +294,18 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 				}
 				if (wnv > 0) {
 					wcx /= wnv; wcy /= wnv; wcz /= wnv;
-					// Probe both sides of the face. For each direction, walk
-					// hull 0 (exact BSP geometry) of every OTHER water model.
-					// If the probe lands inside another water entity, this
-					// face is an internal seam between adjacent water entities.
-					// Note: hull 0 uses the exact brush geometry (nodes/leafs),
-					// NOT hull 1 (clipnodes) which is expanded by player bbox
-					// and would false-positive on nearby but non-overlapping
-					// brushes (e.g. waterfall next to a pool).
+					// Probe both sides of the face; the one that lies OUTSIDE this
+					// brush is the one that can see a seam. If it lands inside another
+					// water entity, this face is buried between two adjacent water
+					// volumes and is never visible.
+					//
+					// Skipping the probe that lands inside THIS brush is what keeps a
+					// coincident twin from deleting the map's water: ww_osaka builds
+					// every river as a func_water and a func_conveyor over the same
+					// brush, so each one's INWARD probe sits inside the other. Culling
+					// on that erased all 9 of its water brushes — 319 of 322 faces —
+					// and the rivers never rendered at all. It is the only map in the
+					// game that does this, and no other map's cull count moves.
 					bool inside_other = false;
 					for (int ps = 0; ps < 2 && !inside_other; ps++) {
 						float sign = ps == 0 ? 1.0f : -1.0f;
@@ -278,22 +314,11 @@ void BSPParser::parse_faces(const uint8_t *data, size_t size) {
 							wcy + ny * sign * 2.0f,
 							wcz + nz * sign * 2.0f
 						};
+						if (point_in_model(face_to_model[f], probe)) continue;
 						for (int wmi : water_model_set) {
 							if (wmi == face_to_model[f]) continue;
-							// Walk hull 0 (nodes/leafs) of the other water model
-							int ni = raw_models[wmi].headnode[0];
-							while (ni >= 0 && (size_t)ni < nodes.size()) {
-								const auto &nd = nodes[ni];
-								if (nd.planenum < 0 || (size_t)nd.planenum >= planes.size()) break;
-								const auto &np = planes[nd.planenum];
-								float d = np.normal[0] * probe[0] + np.normal[1] * probe[1]
-								        + np.normal[2] * probe[2] - np.dist;
-								ni = d >= 0 ? nd.children[0] : nd.children[1];
-							}
-							// Negative ni = leaf index: -(ni+1)
-							int li = -(ni + 1);
-							if (li >= 0 && (size_t)li < leafs.size() &&
-							    leafs[li].contents == CONTENTS_SOLID) {
+							if (movable_water_models.count(wmi)) continue;
+							if (point_in_model(wmi, probe)) {
 								inside_other = true;
 								break;
 							}

--- a/src/parsers/bsp_parser.h
+++ b/src/parsers/bsp_parser.h
@@ -119,6 +119,8 @@ struct BSPLeaf {
 inline constexpr int CONTENTS_EMPTY = -1;
 inline constexpr int CONTENTS_SOLID = -2;
 inline constexpr int CONTENTS_WATER = -3;
+inline constexpr int CONTENTS_SLIME = -4;
+inline constexpr int CONTENTS_LAVA  = -5;
 inline constexpr int CONTENTS_SKY   = -6;
 
 // Tool textures that have no visible geometry at runtime
@@ -175,6 +177,11 @@ struct ParsedFace {
 	float t_offset = 0; // texinfo vecs[1][3] — T axis offset
 	int lm_mins_s = 0;  // floor(min_s / 16) — lightmap origin in texel space
 	int lm_mins_t = 0;  // floor(min_t / 16)
+	// Which liquid a WORLDSPAWN face borders, as CONTENTS_WATER/SLIME/LAVA; 0 when it borders
+	// none. This is the compiler's own answer — it resolved the texture name into leaf contents
+	// at compile time, and GoldSrc read the leaf, not the name. Brush entities do not use this:
+	// their liquid is named by the entity's "skin" key, which is the same CONTENTS_* value.
+	int liquid_contents = 0;
 };
 
 struct ParsedEntity {


### PR DESCRIPTION
Two bugs that each made water silently vanish, in a way nothing outside the converter could see.

**Liquid detection ignored the entity.** It keyed off the texture NAME (a `!`/`*` prefix), so `water4b` and `scrollwater1/2` were never liquid at all — ww_2fort, ww_ravine2 and ww_countryside rendered their pools as opaque brushwork with an alpha on top. A `func_water` brush is now liquid whatever its texture is called.

**The seam cull let two coincident water brushes delete each other.** It probed both sides of a face and culled on either, though its own comment said it culled when the *outside* was inside another water volume. ww_osaka builds every river as a `func_water` laid over a `func_conveyor`, so each one's inward probe sat inside the other: 319 of 322 faces culled, no nodes built, and its rivers had never rendered in any build. Measured across all 24 maps, ww_osaka goes 319 → 27 culled and no other map's count moves.

**Liquid identity now comes from the map, never the texture name.** Brush entities use the `skin` key (= `CONTENTS_*`), worldspawn uses the BSP leaf contents the compiler baked at build time — both what GoldSrc read. The first attempt substring-matched names and got five brushes wrong, including overriding ww_matrox's authored `WaveHeight 5`. ICE is gone with it: no Half-Life engine has `CONTENTS_ICE`, and every ice-textured surface in the game is `CONTENTS_WATER`.

Verified over the ten maps with liquid, and a movable water brush is now exempt from the cull in both directions, since the cull is baked into the converted scene and `func_water` is `CFuncDoor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)